### PR TITLE
Phase 2: Add trial schemas and task specs

### DIFF
--- a/src/comp_model/data/__init__.py
+++ b/src/comp_model/data/__init__.py
@@ -5,6 +5,7 @@ from comp_model.data.validation import (
     validate_block,
     validate_dataset,
     validate_event,
+    validate_event_payload,
     validate_subject,
     validate_trial,
 )
@@ -19,6 +20,7 @@ __all__ = [
     "validate_block",
     "validate_dataset",
     "validate_event",
+    "validate_event_payload",
     "validate_subject",
     "validate_trial",
 ]

--- a/src/comp_model/data/validation.py
+++ b/src/comp_model/data/validation.py
@@ -32,7 +32,7 @@ class _TrialSchemaProtocol(Protocol):
         """
 
 
-def _validate_payload(event: Event, trial_index: int, step_index: int) -> None:
+def validate_event_payload(event: Event, trial_index: int, step_index: int) -> None:
     """Validate required payload keys for one event.
 
     Parameters
@@ -94,7 +94,7 @@ def validate_event(event: Event, trial_index: int, step_index: int) -> None:
             f"Trial {trial_index}, event {step_index}: event_index mismatch "
             f"({event.event_index} != {step_index})"
         )
-    _validate_payload(event, trial_index, step_index)
+    validate_event_payload(event, trial_index, step_index)
 
 
 def validate_trial(trial: Trial, schema: _TrialSchemaProtocol | None = None) -> None:
@@ -214,6 +214,7 @@ __all__ = [
     "validate_block",
     "validate_dataset",
     "validate_event",
+    "validate_event_payload",
     "validate_subject",
     "validate_trial",
 ]

--- a/src/comp_model/tasks/__init__.py
+++ b/src/comp_model/tasks/__init__.py
@@ -1,0 +1,20 @@
+"""Task specifications and declarative trial schemas."""
+
+from comp_model.tasks.schemas import (
+    ASOCIAL_BANDIT_SCHEMA,
+    SOCIAL_POST_OUTCOME_SCHEMA,
+    SOCIAL_PRE_CHOICE_SCHEMA,
+    TrialSchema,
+    TrialSchemaStep,
+)
+from comp_model.tasks.spec import BlockSpec, TaskSpec
+
+__all__ = [
+    "ASOCIAL_BANDIT_SCHEMA",
+    "SOCIAL_POST_OUTCOME_SCHEMA",
+    "SOCIAL_PRE_CHOICE_SCHEMA",
+    "BlockSpec",
+    "TaskSpec",
+    "TrialSchema",
+    "TrialSchemaStep",
+]

--- a/src/comp_model/tasks/schemas.py
+++ b/src/comp_model/tasks/schemas.py
@@ -1,0 +1,148 @@
+"""Declarative event-order schemas for trial structure."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from comp_model.data.schema import EventPhase, Trial
+from comp_model.data.validation import validate_event_payload
+
+
+@dataclass(frozen=True, slots=True)
+class TrialSchemaStep:
+    """Single positional step inside a declarative trial schema.
+
+    Attributes
+    ----------
+    phase
+        Phase expected at this step.
+    node_id
+        Decision-point identifier expected at this step.
+    actor_id
+        Actor expected at this step.
+    action_required
+        Whether the simulation engine must supply an action here.
+    """
+
+    phase: EventPhase
+    node_id: str
+    actor_id: str = "subject"
+    action_required: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class TrialSchema:
+    """Valid event ordering for one trial type.
+
+    Attributes
+    ----------
+    schema_id
+        Stable identifier for the schema.
+    steps
+        Ordered schema steps that each trial must match positionally.
+    """
+
+    schema_id: str
+    steps: tuple[TrialSchemaStep, ...]
+
+    def validate_trial(self, trial: Trial) -> None:
+        """Validate a trial against the schema definition.
+
+        Parameters
+        ----------
+        trial
+            Trial to validate.
+
+        Returns
+        -------
+        None
+            This function raises on any mismatch.
+        """
+
+        if len(trial.events) != len(self.steps):
+            raise ValueError(
+                f"Trial {trial.trial_index}: expected {len(self.steps)} events from "
+                f"schema {self.schema_id!r}, got {len(trial.events)}"
+            )
+
+        for step_index, (event, step) in enumerate(zip(trial.events, self.steps, strict=True)):
+            if event.phase != step.phase:
+                raise ValueError(
+                    f"Trial {trial.trial_index}, event {step_index}: expected phase "
+                    f"{step.phase!r}, got {event.phase!r}"
+                )
+            if event.node_id != step.node_id:
+                raise ValueError(
+                    f"Trial {trial.trial_index}, event {step_index}: expected node_id "
+                    f"{step.node_id!r}, got {event.node_id!r}"
+                )
+            if event.actor_id != step.actor_id:
+                raise ValueError(
+                    f"Trial {trial.trial_index}, event {step_index}: expected actor_id "
+                    f"{step.actor_id!r}, got {event.actor_id!r}"
+                )
+            if event.event_index != step_index:
+                raise ValueError(
+                    f"Trial {trial.trial_index}, event {step_index}: expected event_index "
+                    f"{step_index}, got {event.event_index}"
+                )
+            validate_event_payload(event, trial.trial_index, step_index)
+
+    @property
+    def decision_step_indices(self) -> tuple[int, ...]:
+        """Indices of all decision steps in the schema.
+
+        Returns
+        -------
+        tuple[int, ...]
+            Positions of decision steps.
+        """
+
+        return tuple(
+            index for index, step in enumerate(self.steps) if step.phase == EventPhase.DECISION
+        )
+
+    @property
+    def action_required_indices(self) -> tuple[int, ...]:
+        """Indices of steps that require an externally supplied action.
+
+        Returns
+        -------
+        tuple[int, ...]
+            Positions whose `action_required` flag is true.
+        """
+
+        return tuple(index for index, step in enumerate(self.steps) if step.action_required)
+
+
+ASOCIAL_BANDIT_SCHEMA = TrialSchema(
+    schema_id="asocial_bandit",
+    steps=(
+        TrialSchemaStep(EventPhase.INPUT, "main"),
+        TrialSchemaStep(EventPhase.DECISION, "main", action_required=True),
+        TrialSchemaStep(EventPhase.OUTCOME, "main"),
+        TrialSchemaStep(EventPhase.UPDATE, "main"),
+    ),
+)
+
+SOCIAL_PRE_CHOICE_SCHEMA = TrialSchema(
+    schema_id="social_pre_choice",
+    steps=(
+        TrialSchemaStep(EventPhase.INPUT, "main"),
+        TrialSchemaStep(EventPhase.INPUT, "main", actor_id="demonstrator"),
+        TrialSchemaStep(EventPhase.DECISION, "main", action_required=True),
+        TrialSchemaStep(EventPhase.OUTCOME, "main"),
+        TrialSchemaStep(EventPhase.UPDATE, "main"),
+    ),
+)
+
+SOCIAL_POST_OUTCOME_SCHEMA = TrialSchema(
+    schema_id="social_post_outcome",
+    steps=(
+        TrialSchemaStep(EventPhase.INPUT, "main"),
+        TrialSchemaStep(EventPhase.DECISION, "main", action_required=True),
+        TrialSchemaStep(EventPhase.OUTCOME, "main"),
+        TrialSchemaStep(EventPhase.INPUT, "main", actor_id="demonstrator"),
+        TrialSchemaStep(EventPhase.UPDATE, "main"),
+    ),
+)

--- a/src/comp_model/tasks/spec.py
+++ b/src/comp_model/tasks/spec.py
@@ -1,0 +1,91 @@
+"""Task-level design specifications."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from comp_model.tasks.schemas import TrialSchema
+
+
+def _empty_metadata() -> Mapping[str, Any]:
+    """Create an empty metadata mapping with explicit typing.
+
+    Returns
+    -------
+    Mapping[str, Any]
+        Empty metadata mapping.
+    """
+
+    return {}
+
+
+@dataclass(frozen=True, slots=True)
+class BlockSpec:
+    """Design metadata for one task block.
+
+    Attributes
+    ----------
+    condition
+        Condition label for the block.
+    n_trials
+        Number of trials to run in the block.
+    schema
+        Trial schema executed by the environment.
+    metadata
+        Optional block-level task metadata.
+    """
+
+    condition: str
+    n_trials: int
+    schema: TrialSchema
+    metadata: Mapping[str, Any] = field(default_factory=_empty_metadata)
+
+
+@dataclass(frozen=True, slots=True)
+class TaskSpec:
+    """Immutable specification of a full task design.
+
+    Attributes
+    ----------
+    task_id
+        Stable task identifier.
+    blocks
+        Ordered block specifications for the task.
+    """
+
+    task_id: str
+    blocks: tuple[BlockSpec, ...]
+
+    @property
+    def n_blocks(self) -> int:
+        """Return the number of blocks in the task.
+
+        Returns
+        -------
+        int
+            Number of block specifications.
+        """
+
+        return len(self.blocks)
+
+    @property
+    def conditions(self) -> tuple[str, ...]:
+        """Return condition labels in first-seen order without duplicates.
+
+        Returns
+        -------
+        tuple[str, ...]
+            Ordered unique condition labels.
+        """
+
+        seen: set[str] = set()
+        ordered_conditions: list[str] = []
+        for block in self.blocks:
+            if block.condition not in seen:
+                seen.add(block.condition)
+                ordered_conditions.append(block.condition)
+        return tuple(ordered_conditions)

--- a/tests/test_tasks/test_schemas.py
+++ b/tests/test_tasks/test_schemas.py
@@ -1,0 +1,122 @@
+"""Tests for declarative trial schemas."""
+
+import pytest
+
+from comp_model.data.schema import Event, EventPhase, Trial
+from comp_model.tasks.schemas import (
+    ASOCIAL_BANDIT_SCHEMA,
+    SOCIAL_POST_OUTCOME_SCHEMA,
+    SOCIAL_PRE_CHOICE_SCHEMA,
+)
+
+
+def test_asocial_schema_exposes_decision_and_action_indices() -> None:
+    """Ensure the asocial schema exposes its decision metadata.
+
+    Returns
+    -------
+    None
+        This test asserts schema properties only.
+    """
+
+    assert ASOCIAL_BANDIT_SCHEMA.decision_step_indices == (1,)
+    assert ASOCIAL_BANDIT_SCHEMA.action_required_indices == (1,)
+
+
+def test_social_pre_choice_schema_accepts_matching_trial() -> None:
+    """Ensure the pre-choice social schema validates a matching trial.
+
+    Returns
+    -------
+    None
+        This test only checks successful validation.
+    """
+
+    trial = Trial(
+        trial_index=0,
+        events=(
+            Event(
+                phase=EventPhase.INPUT,
+                event_index=0,
+                node_id="main",
+                payload={"available_actions": (0, 1)},
+            ),
+            Event(
+                phase=EventPhase.INPUT,
+                event_index=1,
+                node_id="main",
+                actor_id="demonstrator",
+                payload={
+                    "available_actions": (0, 1),
+                    "observation": {"social_action": 1, "social_reward": 0.0},
+                },
+            ),
+            Event(phase=EventPhase.DECISION, event_index=2, node_id="main", payload={"action": 1}),
+            Event(phase=EventPhase.OUTCOME, event_index=3, node_id="main", payload={"reward": 1.0}),
+            Event(phase=EventPhase.UPDATE, event_index=4, node_id="main", payload={}),
+        ),
+    )
+
+    SOCIAL_PRE_CHOICE_SCHEMA.validate_trial(trial)
+
+
+def test_social_post_outcome_schema_rejects_actor_mismatch() -> None:
+    """Ensure actor mismatches are rejected with a clear error.
+
+    Returns
+    -------
+    None
+        This test raises on schema mismatch.
+    """
+
+    trial = Trial(
+        trial_index=0,
+        events=(
+            Event(
+                phase=EventPhase.INPUT,
+                event_index=0,
+                node_id="main",
+                payload={"available_actions": (0, 1)},
+            ),
+            Event(phase=EventPhase.DECISION, event_index=1, node_id="main", payload={"action": 1}),
+            Event(phase=EventPhase.OUTCOME, event_index=2, node_id="main", payload={"reward": 1.0}),
+            Event(
+                phase=EventPhase.INPUT,
+                event_index=3,
+                node_id="main",
+                payload={
+                    "available_actions": (0, 1),
+                    "observation": {"social_action": 0, "social_reward": 1.0},
+                },
+            ),
+            Event(phase=EventPhase.UPDATE, event_index=4, node_id="main", payload={}),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="actor_id"):
+        SOCIAL_POST_OUTCOME_SCHEMA.validate_trial(trial)
+
+
+def test_schema_rejects_wrong_event_count() -> None:
+    """Ensure schema validation checks trial length.
+
+    Returns
+    -------
+    None
+        This test raises on mismatched event count.
+    """
+
+    trial = Trial(
+        trial_index=0,
+        events=(
+            Event(
+                phase=EventPhase.INPUT,
+                event_index=0,
+                node_id="main",
+                payload={"available_actions": (0, 1)},
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="expected 4 events"):
+        ASOCIAL_BANDIT_SCHEMA.validate_trial(trial)

--- a/tests/test_tasks/test_spec.py
+++ b/tests/test_tasks/test_spec.py
@@ -1,0 +1,42 @@
+"""Tests for task-level design specifications."""
+
+from comp_model.tasks.schemas import ASOCIAL_BANDIT_SCHEMA, SOCIAL_PRE_CHOICE_SCHEMA
+from comp_model.tasks.spec import BlockSpec, TaskSpec
+
+
+def test_task_spec_reports_number_of_blocks() -> None:
+    """Ensure task specs report block counts correctly.
+
+    Returns
+    -------
+    None
+        This test asserts the `n_blocks` property.
+    """
+
+    task = TaskSpec(
+        task_id="bandit",
+        blocks=(BlockSpec(condition="a", n_trials=10, schema=ASOCIAL_BANDIT_SCHEMA),),
+    )
+
+    assert task.n_blocks == 1
+
+
+def test_task_spec_conditions_preserve_first_seen_order() -> None:
+    """Ensure duplicate conditions are collapsed in order.
+
+    Returns
+    -------
+    None
+        This test asserts the ordered unique conditions.
+    """
+
+    task = TaskSpec(
+        task_id="mixed",
+        blocks=(
+            BlockSpec(condition="baseline", n_trials=5, schema=ASOCIAL_BANDIT_SCHEMA),
+            BlockSpec(condition="social", n_trials=5, schema=SOCIAL_PRE_CHOICE_SCHEMA),
+            BlockSpec(condition="baseline", n_trials=5, schema=ASOCIAL_BANDIT_SCHEMA),
+        ),
+    )
+
+    assert task.conditions == ("baseline", "social")


### PR DESCRIPTION
## Summary
- add declarative trial schema and schema-step definitions
- add built-in asocial and social bandit schemas
- add block and task specification types with task tests