### PR TITLE
Phase 4: Add kernel specs and protocols

### DIFF
--- a/src/comp_model/models/kernels/__init__.py
+++ b/src/comp_model/models/kernels/__init__.py
@@ -1,5 +1,23 @@
 """Kernel implementations and shared parameter transforms."""
 
+from comp_model.models.kernels.base import (
+    DecisionTrialViewLike,
+    InitSpec,
+    ModelKernel,
+    ModelKernelSpec,
+    ParameterSpec,
+    PriorSpec,
+)
 from comp_model.models.kernels.transforms import TRANSFORM_REGISTRY, Transform, get_transform
 
-__all__ = ["TRANSFORM_REGISTRY", "Transform", "get_transform"]
+__all__ = [
+    "TRANSFORM_REGISTRY",
+    "DecisionTrialViewLike",
+    "InitSpec",
+    "ModelKernel",
+    "ModelKernelSpec",
+    "ParameterSpec",
+    "PriorSpec",
+    "Transform",
+    "get_transform",
+]

--- a/src/comp_model/models/kernels/base.py
+++ b/src/comp_model/models/kernels/base.py
@@ -1,0 +1,237 @@
+"""Backend-agnostic kernel metadata and protocols."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class PriorSpec:
+    """Prior metadata for a model parameter.
+
+    Attributes
+    ----------
+    family
+        Prior family identifier, such as ``"normal"``.
+    kwargs
+        Hyperparameters for the prior family.
+    parameterization
+        Scale on which the prior is defined.
+    """
+
+    family: str
+    kwargs: Mapping[str, float]
+    parameterization: str = "unconstrained"
+
+
+@dataclass(frozen=True, slots=True)
+class InitSpec:
+    """Initialization metadata for MLE optimization.
+
+    Attributes
+    ----------
+    strategy
+        Initialization strategy identifier.
+    kwargs
+        Strategy-specific keyword arguments.
+    default_unconstrained
+        Default unconstrained starting value.
+    """
+
+    strategy: str
+    kwargs: Mapping[str, float]
+    default_unconstrained: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class ParameterSpec:
+    """Metadata for one free model parameter.
+
+    Attributes
+    ----------
+    name
+        Parameter name exposed to inference code.
+    transform_id
+        Identifier in the transform registry.
+    description
+        Human-readable description of the parameter.
+    prior
+        Optional prior metadata for Bayesian inference.
+    mle_init
+        Optional initialization metadata for MLE.
+    """
+
+    name: str
+    transform_id: str
+    description: str = ""
+    prior: PriorSpec | None = None
+    mle_init: InitSpec | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ModelKernelSpec:
+    """Static metadata describing a model kernel.
+
+    Attributes
+    ----------
+    model_id
+        Stable identifier for the kernel.
+    parameter_specs
+        Ordered parameter metadata for the kernel.
+    requires_social
+        Whether the kernel reads social fields from decision views.
+    n_actions
+        Optional fixed action count. ``None`` means infer from data.
+    state_reset_policy
+        Policy for resetting kernel state, either ``"per_subject"`` or ``"per_block"``.
+    description
+        Human-readable model description.
+    """
+
+    model_id: str
+    parameter_specs: tuple[ParameterSpec, ...]
+    requires_social: bool = False
+    n_actions: int | None = None
+    state_reset_policy: str = "per_subject"
+    description: str = ""
+
+
+class DecisionTrialViewLike(Protocol):
+    """Structural protocol for extractor output consumed by kernels.
+
+    Attributes
+    ----------
+    trial_index
+        Trial index for the decision.
+    available_actions
+        Legal actions at the decision point.
+    choice
+        Chosen action value.
+    reward
+        Observed reward, if present.
+    observation
+        Subject-facing observation payload.
+    social_action
+        Observed demonstrator action, if present.
+    social_reward
+        Observed demonstrator reward, if present.
+    metadata
+        Additional extractor metadata.
+    """
+
+    trial_index: int
+    available_actions: tuple[int, ...]
+    choice: int
+    reward: float | None
+    observation: Mapping[str, Any]
+    social_action: int | None
+    social_reward: float | None
+    metadata: Mapping[str, Any]
+
+
+StateT = TypeVar("StateT")
+ParamsT = TypeVar("ParamsT")
+
+
+class ModelKernel(Protocol, Generic[StateT, ParamsT]):
+    """Protocol shared by all backend-agnostic model kernels."""
+
+    @classmethod
+    def spec(cls) -> ModelKernelSpec:
+        """Return static kernel metadata.
+
+        Returns
+        -------
+        ModelKernelSpec
+            Kernel specification used by inference code.
+        """
+
+        ...
+
+    def parse_params(self, raw: dict[str, float]) -> ParamsT:
+        """Convert unconstrained parameter values into typed parameters.
+
+        Parameters
+        ----------
+        raw
+            Raw unconstrained parameter values keyed by parameter name.
+
+        Returns
+        -------
+        ParamsT
+            Parsed parameter object for the kernel.
+        """
+
+        ...
+
+    def initial_state(self, n_actions: int, params: ParamsT) -> StateT:
+        """Construct the initial latent state.
+
+        Parameters
+        ----------
+        n_actions
+            Number of legal actions in the task.
+        params
+            Parsed kernel parameters.
+
+        Returns
+        -------
+        StateT
+            Initial latent state.
+        """
+
+        ...
+
+    def action_probabilities(
+        self,
+        state: StateT,
+        view: DecisionTrialViewLike,
+        params: ParamsT,
+    ) -> tuple[float, ...]:
+        """Return action probabilities for the current decision view.
+
+        Parameters
+        ----------
+        state
+            Current latent state.
+        view
+            Extracted decision record.
+        params
+            Parsed kernel parameters.
+
+        Returns
+        -------
+        tuple[float, ...]
+            Probabilities aligned with ``view.available_actions``.
+        """
+
+        ...
+
+    def next_state(
+        self,
+        state: StateT,
+        view: DecisionTrialViewLike,
+        params: ParamsT,
+    ) -> StateT:
+        """Update the latent state after the decision outcome.
+
+        Parameters
+        ----------
+        state
+            Current latent state.
+        view
+            Extracted decision record.
+        params
+            Parsed kernel parameters.
+
+        Returns
+        -------
+        StateT
+            Updated latent state.
+        """
+
+        ...

--- a/tests/test_models/test_kernel_base.py
+++ b/tests/test_models/test_kernel_base.py
@@ -1,0 +1,42 @@
+"""Tests for kernel metadata structures."""
+
+from comp_model.models.kernels.base import InitSpec, ModelKernelSpec, ParameterSpec, PriorSpec
+
+
+def test_parameter_spec_captures_prior_and_init_metadata() -> None:
+    """Ensure parameter metadata stores prior and init specifications.
+
+    Returns
+    -------
+    None
+        This test asserts stored dataclass values.
+    """
+
+    prior = PriorSpec(family="normal", kwargs={"mu": 0.0, "sigma": 1.0})
+    init = InitSpec(strategy="fixed", kwargs={}, default_unconstrained=0.5)
+    parameter = ParameterSpec(
+        name="alpha",
+        transform_id="sigmoid",
+        description="learning rate",
+        prior=prior,
+        mle_init=init,
+    )
+
+    assert parameter.prior == prior
+    assert parameter.mle_init == init
+
+
+def test_model_kernel_spec_defaults_match_plan() -> None:
+    """Ensure kernel spec defaults align with the implementation plan.
+
+    Returns
+    -------
+    None
+        This test asserts the metadata defaults.
+    """
+
+    spec = ModelKernelSpec(model_id="demo", parameter_specs=())
+
+    assert spec.requires_social is False
+    assert spec.n_actions is None
+    assert spec.state_reset_policy == "per_subject"


### PR DESCRIPTION
## Summary
- add prior, init, parameter, and kernel specification dataclasses
- add the backend-agnostic model kernel protocol
- add tests for kernel metadata defaults