### PR TITLE
Phase 5: Add decision-view extraction

### DIFF
--- a/src/comp_model/data/__init__.py
+++ b/src/comp_model/data/__init__.py
@@ -1,5 +1,6 @@
 """Canonical event-based data structures and validation helpers."""
 
+from comp_model.data.extractors import DecisionTrialView, extract_decision_views
 from comp_model.data.schema import Block, Dataset, Event, EventPhase, SubjectData, Trial
 from comp_model.data.validation import (
     validate_block,
@@ -13,10 +14,12 @@ from comp_model.data.validation import (
 __all__ = [
     "Block",
     "Dataset",
+    "DecisionTrialView",
     "Event",
     "EventPhase",
     "SubjectData",
     "Trial",
+    "extract_decision_views",
     "validate_block",
     "validate_dataset",
     "validate_event",

--- a/src/comp_model/data/extractors.py
+++ b/src/comp_model/data/extractors.py
@@ -1,0 +1,134 @@
+"""Schema-driven extraction from event traces to model-facing decision views."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from comp_model.data.schema import EventPhase, Trial
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from comp_model.tasks.schemas import TrialSchema
+
+
+def _empty_metadata() -> Mapping[str, Any]:
+    """Create an empty metadata mapping with explicit typing.
+
+    Returns
+    -------
+    Mapping[str, Any]
+        Empty metadata mapping.
+    """
+
+    return {}
+
+
+@dataclass(frozen=True, slots=True)
+class DecisionTrialView:
+    """Flat per-decision record consumed by model kernels.
+
+    Attributes
+    ----------
+    trial_index
+        Index of the source trial within its block.
+    available_actions
+        Legal actions at the decision point.
+    choice
+        Chosen action value.
+    reward
+        Observed reward, if present.
+    observation
+        Subject-facing observation payload.
+    social_action
+        Observed demonstrator action, if present.
+    social_reward
+        Observed demonstrator reward, if present.
+    metadata
+        Additional extractor metadata.
+    """
+
+    trial_index: int
+    available_actions: tuple[int, ...]
+    choice: int
+    reward: float | None = None
+    observation: Mapping[str, Any] = field(default_factory=_empty_metadata)
+    social_action: int | None = None
+    social_reward: float | None = None
+    metadata: Mapping[str, Any] = field(default_factory=_empty_metadata)
+
+
+def extract_decision_views(trial: Trial, schema: TrialSchema) -> tuple[DecisionTrialView, ...]:
+    """Extract flat decision records from a schema-validated trial.
+
+    Parameters
+    ----------
+    trial
+        Trial whose events should be extracted.
+    schema
+        Schema defining the positional meaning of each event.
+
+    Returns
+    -------
+    tuple[DecisionTrialView, ...]
+        One flat record for each decision step in the schema.
+    """
+
+    schema.validate_trial(trial)
+
+    events = trial.events
+    steps = schema.steps
+    views: list[DecisionTrialView] = []
+
+    for decision_step_index in schema.decision_step_indices:
+        decision_step = steps[decision_step_index]
+        decision_event = events[decision_step_index]
+        decision_actor = decision_step.actor_id
+        decision_node = decision_step.node_id
+
+        available_actions: tuple[int, ...] | None = None
+        observation: dict[str, Any] = {}
+        social_action: int | None = None
+        social_reward: float | None = None
+        reward: float | None = None
+
+        for event, step in zip(events, steps, strict=True):
+            if step.phase == EventPhase.INPUT:
+                if step.actor_id == decision_actor:
+                    if step.node_id == decision_node:
+                        available_actions = tuple(event.payload["available_actions"])
+                        raw_observation = event.payload.get("observation")
+                        if isinstance(raw_observation, dict):
+                            observation = dict(raw_observation)
+                        elif raw_observation is not None:
+                            observation = {"value": raw_observation}
+                else:
+                    social_payload = event.payload.get("observation", {})
+                    if isinstance(social_payload, dict):
+                        if "social_action" in social_payload:
+                            social_action = int(social_payload["social_action"])
+                        if "social_reward" in social_payload:
+                            social_reward = float(social_payload["social_reward"])
+            elif step.phase == EventPhase.OUTCOME and step.node_id == decision_node:
+                reward = float(event.payload["reward"])
+
+        if available_actions is None:
+            raise ValueError(
+                f"Trial {trial.trial_index}: no subject INPUT event found for decision at "
+                f"step {decision_step_index}"
+            )
+
+        views.append(
+            DecisionTrialView(
+                trial_index=trial.trial_index,
+                available_actions=available_actions,
+                choice=int(decision_event.payload["action"]),
+                reward=reward,
+                observation=observation,
+                social_action=social_action,
+                social_reward=social_reward,
+            )
+        )
+
+    return tuple(views)

--- a/src/comp_model/models/kernels/__init__.py
+++ b/src/comp_model/models/kernels/__init__.py
@@ -1,7 +1,6 @@
 """Kernel implementations and shared parameter transforms."""
 
 from comp_model.models.kernels.base import (
-    DecisionTrialViewLike,
     InitSpec,
     ModelKernel,
     ModelKernelSpec,
@@ -12,7 +11,6 @@ from comp_model.models.kernels.transforms import TRANSFORM_REGISTRY, Transform, 
 
 __all__ = [
     "TRANSFORM_REGISTRY",
-    "DecisionTrialViewLike",
     "InitSpec",
     "ModelKernel",
     "ModelKernelSpec",

--- a/src/comp_model/models/kernels/base.py
+++ b/src/comp_model/models/kernels/base.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
+from typing import TYPE_CHECKING, Generic, Protocol, TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+    from comp_model.data.extractors import DecisionTrialView
 
 
 @dataclass(frozen=True, slots=True)
@@ -100,39 +102,6 @@ class ModelKernelSpec:
     description: str = ""
 
 
-class DecisionTrialViewLike(Protocol):
-    """Structural protocol for extractor output consumed by kernels.
-
-    Attributes
-    ----------
-    trial_index
-        Trial index for the decision.
-    available_actions
-        Legal actions at the decision point.
-    choice
-        Chosen action value.
-    reward
-        Observed reward, if present.
-    observation
-        Subject-facing observation payload.
-    social_action
-        Observed demonstrator action, if present.
-    social_reward
-        Observed demonstrator reward, if present.
-    metadata
-        Additional extractor metadata.
-    """
-
-    trial_index: int
-    available_actions: tuple[int, ...]
-    choice: int
-    reward: float | None
-    observation: Mapping[str, Any]
-    social_action: int | None
-    social_reward: float | None
-    metadata: Mapping[str, Any]
-
-
 StateT = TypeVar("StateT")
 ParamsT = TypeVar("ParamsT")
 
@@ -189,7 +158,7 @@ class ModelKernel(Protocol, Generic[StateT, ParamsT]):
     def action_probabilities(
         self,
         state: StateT,
-        view: DecisionTrialViewLike,
+        view: DecisionTrialView,
         params: ParamsT,
     ) -> tuple[float, ...]:
         """Return action probabilities for the current decision view.
@@ -214,7 +183,7 @@ class ModelKernel(Protocol, Generic[StateT, ParamsT]):
     def next_state(
         self,
         state: StateT,
-        view: DecisionTrialViewLike,
+        view: DecisionTrialView,
         params: ParamsT,
     ) -> StateT:
         """Update the latent state after the decision outcome.

--- a/tests/test_data/test_extractors.py
+++ b/tests/test_data/test_extractors.py
@@ -1,0 +1,155 @@
+"""Tests for schema-driven decision view extraction."""
+
+from comp_model.data.extractors import extract_decision_views
+from comp_model.data.schema import Event, EventPhase, Trial
+from comp_model.tasks.schemas import (
+    ASOCIAL_BANDIT_SCHEMA,
+    SOCIAL_POST_OUTCOME_SCHEMA,
+    SOCIAL_PRE_CHOICE_SCHEMA,
+)
+
+
+def test_extract_asocial_trial_view() -> None:
+    """Ensure asocial trials extract choice and reward correctly.
+
+    Returns
+    -------
+    None
+        This test asserts extracted scalar fields.
+    """
+
+    trial = Trial(
+        trial_index=0,
+        events=(
+            Event(
+                phase=EventPhase.INPUT,
+                event_index=0,
+                node_id="main",
+                payload={"available_actions": (0, 1), "observation": {"cue": "left"}},
+            ),
+            Event(
+                phase=EventPhase.DECISION,
+                event_index=1,
+                node_id="main",
+                payload={"action": 1},
+            ),
+            Event(
+                phase=EventPhase.OUTCOME,
+                event_index=2,
+                node_id="main",
+                payload={"reward": 0.5},
+            ),
+            Event(phase=EventPhase.UPDATE, event_index=3, node_id="main", payload={}),
+        ),
+    )
+
+    (view,) = extract_decision_views(trial, ASOCIAL_BANDIT_SCHEMA)
+
+    assert view.available_actions == (0, 1)
+    assert view.choice == 1
+    assert view.reward == 0.5
+    assert dict(view.observation) == {"cue": "left"}
+    assert view.social_action is None
+
+
+def test_extract_social_pre_choice_view_reads_social_fields() -> None:
+    """Ensure pre-choice social input is unpacked into social fields.
+
+    Returns
+    -------
+    None
+        This test asserts extracted demonstrator information.
+    """
+
+    trial = Trial(
+        trial_index=1,
+        events=(
+            Event(
+                phase=EventPhase.INPUT,
+                event_index=0,
+                node_id="main",
+                payload={"available_actions": (0, 1)},
+            ),
+            Event(
+                phase=EventPhase.INPUT,
+                event_index=1,
+                node_id="main",
+                actor_id="demonstrator",
+                payload={
+                    "available_actions": (0, 1),
+                    "observation": {"social_action": 0, "social_reward": 1.0},
+                },
+            ),
+            Event(
+                phase=EventPhase.DECISION,
+                event_index=2,
+                node_id="main",
+                payload={"action": 1},
+            ),
+            Event(
+                phase=EventPhase.OUTCOME,
+                event_index=3,
+                node_id="main",
+                payload={"reward": 0.0},
+            ),
+            Event(phase=EventPhase.UPDATE, event_index=4, node_id="main", payload={}),
+        ),
+    )
+
+    (view,) = extract_decision_views(trial, SOCIAL_PRE_CHOICE_SCHEMA)
+
+    assert view.choice == 1
+    assert view.social_action == 0
+    assert view.social_reward == 1.0
+
+
+def test_extract_social_post_outcome_view_ignores_position_difference() -> None:
+    """Ensure post-outcome social input extracts the same flat fields.
+
+    Returns
+    -------
+    None
+        This test asserts schema-order agnostic extraction.
+    """
+
+    trial = Trial(
+        trial_index=2,
+        events=(
+            Event(
+                phase=EventPhase.INPUT,
+                event_index=0,
+                node_id="main",
+                payload={"available_actions": (0, 1)},
+            ),
+            Event(
+                phase=EventPhase.DECISION,
+                event_index=1,
+                node_id="main",
+                payload={"action": 0},
+            ),
+            Event(
+                phase=EventPhase.OUTCOME,
+                event_index=2,
+                node_id="main",
+                payload={"reward": 1.0},
+            ),
+            Event(
+                phase=EventPhase.INPUT,
+                event_index=3,
+                node_id="main",
+                actor_id="demonstrator",
+                payload={
+                    "available_actions": (0, 1),
+                    "observation": {"social_action": 1, "social_reward": 0.0},
+                },
+            ),
+            Event(phase=EventPhase.UPDATE, event_index=4, node_id="main", payload={}),
+        ),
+    )
+
+    (view,) = extract_decision_views(trial, SOCIAL_POST_OUTCOME_SCHEMA)
+
+    assert view.choice == 0
+    assert view.reward == 1.0
+    assert view.social_action == 1
+    assert view.social_reward == 0.0


### PR DESCRIPTION
## Summary
- add DecisionTrialView as the flat kernel-facing replay record
- add schema-driven extraction from event traces to decision views
- add extraction tests for asocial and social schemas