### PR TITLE
Phase 6: Add Q-learning kernels

### DIFF
--- a/src/comp_model/models/kernels/__init__.py
+++ b/src/comp_model/models/kernels/__init__.py
@@ -1,5 +1,6 @@
 """Kernel implementations and shared parameter transforms."""
 
+from comp_model.models.kernels.asocial_q_learning import AsocialQLearningKernel, QParams, QState
 from comp_model.models.kernels.base import (
     InitSpec,
     ModelKernel,
@@ -7,15 +8,26 @@ from comp_model.models.kernels.base import (
     ParameterSpec,
     PriorSpec,
 )
+from comp_model.models.kernels.social_observed_outcome_q import (
+    SocialObservedOutcomeQKernel,
+    SocialQParams,
+    SocialQState,
+)
 from comp_model.models.kernels.transforms import TRANSFORM_REGISTRY, Transform, get_transform
 
 __all__ = [
     "TRANSFORM_REGISTRY",
+    "AsocialQLearningKernel",
     "InitSpec",
     "ModelKernel",
     "ModelKernelSpec",
     "ParameterSpec",
     "PriorSpec",
+    "QParams",
+    "QState",
+    "SocialObservedOutcomeQKernel",
+    "SocialQParams",
+    "SocialQState",
     "Transform",
     "get_transform",
 ]

--- a/src/comp_model/models/kernels/asocial_q_learning.py
+++ b/src/comp_model/models/kernels/asocial_q_learning.py
@@ -1,0 +1,189 @@
+"""Asocial Q-learning kernel."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from comp_model.models.kernels.base import InitSpec, ModelKernelSpec, ParameterSpec, PriorSpec
+from comp_model.models.kernels.transforms import get_transform
+
+if TYPE_CHECKING:
+    from comp_model.data.extractors import DecisionTrialView
+
+
+@dataclass(frozen=True, slots=True)
+class QParams:
+    """Parsed parameters for the asocial Q-learning kernel.
+
+    Attributes
+    ----------
+    alpha
+        Learning rate in `(0, 1)`.
+    beta
+        Inverse temperature in `(0, +inf)`.
+    """
+
+    alpha: float
+    beta: float
+
+
+@dataclass(slots=True)
+class QState:
+    """Latent Q-values for an asocial learning agent.
+
+    Attributes
+    ----------
+    q_values
+        Per-action Q-values indexed by action value.
+    """
+
+    q_values: list[float]
+
+
+class AsocialQLearningKernel:
+    """Standard softmax Q-learning kernel for asocial bandit tasks."""
+
+    @classmethod
+    def spec(cls) -> ModelKernelSpec:
+        """Return static metadata for the asocial kernel.
+
+        Returns
+        -------
+        ModelKernelSpec
+            Static kernel specification.
+        """
+
+        return ModelKernelSpec(
+            model_id="asocial_q_learning",
+            parameter_specs=(
+                ParameterSpec(
+                    name="alpha",
+                    transform_id="sigmoid",
+                    description="learning rate",
+                    prior=PriorSpec(family="normal", kwargs={"mu": 0.0, "sigma": 1.5}),
+                    mle_init=InitSpec(
+                        strategy="fixed",
+                        kwargs={},
+                        default_unconstrained=0.0,
+                    ),
+                ),
+                ParameterSpec(
+                    name="beta",
+                    transform_id="softplus",
+                    description="inverse temperature",
+                    prior=PriorSpec(family="normal", kwargs={"mu": 0.0, "sigma": 2.0}),
+                    mle_init=InitSpec(
+                        strategy="fixed",
+                        kwargs={},
+                        default_unconstrained=1.0,
+                    ),
+                ),
+            ),
+            requires_social=False,
+            state_reset_policy="per_subject",
+        )
+
+    def parse_params(self, raw: dict[str, float]) -> QParams:
+        """Transform unconstrained parameters into typed kernel parameters.
+
+        Parameters
+        ----------
+        raw
+            Unconstrained parameter values keyed by parameter name.
+
+        Returns
+        -------
+        QParams
+            Typed parameter object.
+        """
+
+        return QParams(
+            alpha=get_transform("sigmoid").forward(raw["alpha"]),
+            beta=get_transform("softplus").forward(raw["beta"]),
+        )
+
+    def initial_state(self, n_actions: int, params: QParams) -> QState:
+        """Construct the initial latent Q-state.
+
+        Parameters
+        ----------
+        n_actions
+            Number of legal actions in the task.
+        params
+            Parsed kernel parameters.
+
+        Returns
+        -------
+        QState
+            Initial Q-values set to ``0.5``.
+        """
+
+        del params
+        return QState(q_values=[0.5] * n_actions)
+
+    def action_probabilities(
+        self,
+        state: QState,
+        view: DecisionTrialView,
+        params: QParams,
+    ) -> tuple[float, ...]:
+        """Compute softmax action probabilities for the current state.
+
+        Parameters
+        ----------
+        state
+            Current latent Q-values.
+        view
+            Extracted decision record.
+        params
+            Parsed kernel parameters.
+
+        Returns
+        -------
+        tuple[float, ...]
+            Probabilities aligned with ``view.available_actions``.
+        """
+
+        logits = np.array(
+            [params.beta * state.q_values[action] for action in view.available_actions]
+        )
+        logits -= logits.max()
+        exp_logits = np.exp(logits)
+        probabilities = exp_logits / exp_logits.sum()
+        probabilities = np.clip(probabilities, 1e-15, None)
+        probabilities /= probabilities.sum()
+        return tuple(float(value) for value in probabilities)
+
+    def next_state(
+        self,
+        state: QState,
+        view: DecisionTrialView,
+        params: QParams,
+    ) -> QState:
+        """Update the chosen action's Q-value from reward prediction error.
+
+        Parameters
+        ----------
+        state
+            Current latent Q-values.
+        view
+            Extracted decision record.
+        params
+            Parsed kernel parameters.
+
+        Returns
+        -------
+        QState
+            Updated latent state.
+        """
+
+        updated_q_values = list(state.q_values)
+        if view.reward is not None:
+            chosen_action = view.choice
+            updated_q_values[chosen_action] += params.alpha * (
+                view.reward - updated_q_values[chosen_action]
+            )
+        return QState(q_values=updated_q_values)

--- a/src/comp_model/models/kernels/social_observed_outcome_q.py
+++ b/src/comp_model/models/kernels/social_observed_outcome_q.py
@@ -1,0 +1,189 @@
+"""Social Q-learning kernel with observed demonstrator outcomes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from comp_model.models.kernels.base import ModelKernelSpec, ParameterSpec
+from comp_model.models.kernels.transforms import get_transform
+
+if TYPE_CHECKING:
+    from comp_model.data.extractors import DecisionTrialView
+
+
+@dataclass(frozen=True, slots=True)
+class SocialQParams:
+    """Parsed parameters for the social observed-outcome kernel.
+
+    Attributes
+    ----------
+    alpha_self
+        Learning rate for self-generated outcomes.
+    alpha_other
+        Learning rate for demonstrator outcomes.
+    beta
+        Inverse temperature for choice stochasticity.
+    """
+
+    alpha_self: float
+    alpha_other: float
+    beta: float
+
+
+@dataclass(slots=True)
+class SocialQState:
+    """Latent Q-values for a socially informed learning agent.
+
+    Attributes
+    ----------
+    q_values
+        Per-action Q-values indexed by action value.
+    """
+
+    q_values: list[float]
+
+
+class SocialObservedOutcomeQKernel:
+    """Q-learning kernel that updates from self and demonstrator outcomes."""
+
+    @classmethod
+    def spec(cls) -> ModelKernelSpec:
+        """Return static metadata for the social kernel.
+
+        Returns
+        -------
+        ModelKernelSpec
+            Static kernel specification.
+        """
+
+        return ModelKernelSpec(
+            model_id="social_observed_outcome_q",
+            parameter_specs=(
+                ParameterSpec(
+                    name="alpha_self",
+                    transform_id="sigmoid",
+                    description="self learning rate",
+                ),
+                ParameterSpec(
+                    name="alpha_other",
+                    transform_id="sigmoid",
+                    description="social learning rate",
+                ),
+                ParameterSpec(
+                    name="beta",
+                    transform_id="softplus",
+                    description="inverse temperature",
+                ),
+            ),
+            requires_social=True,
+            state_reset_policy="per_subject",
+        )
+
+    def parse_params(self, raw: dict[str, float]) -> SocialQParams:
+        """Transform unconstrained parameters into typed social parameters.
+
+        Parameters
+        ----------
+        raw
+            Unconstrained parameter values keyed by parameter name.
+
+        Returns
+        -------
+        SocialQParams
+            Typed parameter object.
+        """
+
+        return SocialQParams(
+            alpha_self=get_transform("sigmoid").forward(raw["alpha_self"]),
+            alpha_other=get_transform("sigmoid").forward(raw["alpha_other"]),
+            beta=get_transform("softplus").forward(raw["beta"]),
+        )
+
+    def initial_state(self, n_actions: int, params: SocialQParams) -> SocialQState:
+        """Construct the initial latent Q-state.
+
+        Parameters
+        ----------
+        n_actions
+            Number of legal actions in the task.
+        params
+            Parsed kernel parameters.
+
+        Returns
+        -------
+        SocialQState
+            Initial Q-values set to ``0.5``.
+        """
+
+        del params
+        return SocialQState(q_values=[0.5] * n_actions)
+
+    def action_probabilities(
+        self,
+        state: SocialQState,
+        view: DecisionTrialView,
+        params: SocialQParams,
+    ) -> tuple[float, ...]:
+        """Compute softmax action probabilities for the current state.
+
+        Parameters
+        ----------
+        state
+            Current latent Q-values.
+        view
+            Extracted decision record.
+        params
+            Parsed kernel parameters.
+
+        Returns
+        -------
+        tuple[float, ...]
+            Probabilities aligned with ``view.available_actions``.
+        """
+
+        logits = np.array(
+            [params.beta * state.q_values[action] for action in view.available_actions]
+        )
+        logits -= logits.max()
+        exp_logits = np.exp(logits)
+        probabilities = exp_logits / exp_logits.sum()
+        probabilities = np.clip(probabilities, 1e-15, None)
+        probabilities /= probabilities.sum()
+        return tuple(float(value) for value in probabilities)
+
+    def next_state(
+        self,
+        state: SocialQState,
+        view: DecisionTrialView,
+        params: SocialQParams,
+    ) -> SocialQState:
+        """Update Q-values from self and social outcomes.
+
+        Parameters
+        ----------
+        state
+            Current latent Q-values.
+        view
+            Extracted decision record.
+        params
+            Parsed kernel parameters.
+
+        Returns
+        -------
+        SocialQState
+            Updated latent state.
+        """
+
+        updated_q_values = list(state.q_values)
+        if view.reward is not None:
+            updated_q_values[view.choice] += params.alpha_self * (
+                view.reward - updated_q_values[view.choice]
+            )
+        if view.social_action is not None and view.social_reward is not None:
+            updated_q_values[view.social_action] += params.alpha_other * (
+                view.social_reward - updated_q_values[view.social_action]
+            )
+        return SocialQState(q_values=updated_q_values)

--- a/tests/test_models/test_asocial_q_learning.py
+++ b/tests/test_models/test_asocial_q_learning.py
@@ -1,0 +1,51 @@
+"""Tests for the asocial Q-learning kernel."""
+
+import math
+
+from comp_model.data.extractors import DecisionTrialView
+from comp_model.models.kernels.asocial_q_learning import AsocialQLearningKernel, QState
+
+
+def test_asocial_kernel_action_probabilities_sum_to_one() -> None:
+    """Ensure asocial action probabilities are normalized.
+
+    Returns
+    -------
+    None
+        This test asserts probability normalization.
+    """
+
+    kernel = AsocialQLearningKernel()
+    params = kernel.parse_params({"alpha": 0.0, "beta": 1.0})
+    state = QState(q_values=[0.25, 0.75])
+    view = DecisionTrialView(trial_index=0, available_actions=(0, 1), choice=1)
+
+    probabilities = kernel.action_probabilities(state, view, params)
+
+    assert math.isclose(sum(probabilities), 1.0, rel_tol=1e-12, abs_tol=1e-12)
+    assert probabilities[1] > probabilities[0]
+
+
+def test_asocial_kernel_updates_chosen_q_value() -> None:
+    """Ensure only the chosen action's Q-value is updated.
+
+    Returns
+    -------
+    None
+        This test asserts the Q-learning update rule.
+    """
+
+    kernel = AsocialQLearningKernel()
+    params = kernel.parse_params({"alpha": 0.0, "beta": 1.0})
+    state = kernel.initial_state(2, params)
+    view = DecisionTrialView(
+        trial_index=0,
+        available_actions=(0, 1),
+        choice=1,
+        reward=1.0,
+    )
+
+    next_state = kernel.next_state(state, view, params)
+
+    assert next_state.q_values[0] == 0.5
+    assert next_state.q_values[1] > 0.5

--- a/tests/test_models/test_social_observed_outcome_q.py
+++ b/tests/test_models/test_social_observed_outcome_q.py
@@ -1,0 +1,43 @@
+"""Tests for the social observed-outcome Q-learning kernel."""
+
+from comp_model.data.extractors import DecisionTrialView
+from comp_model.models.kernels.social_observed_outcome_q import SocialObservedOutcomeQKernel
+
+
+def test_social_kernel_reports_social_requirement() -> None:
+    """Ensure the social kernel declares that it consumes social input.
+
+    Returns
+    -------
+    None
+        This test asserts static kernel metadata.
+    """
+
+    assert SocialObservedOutcomeQKernel.spec().requires_social is True
+
+
+def test_social_kernel_updates_self_and_social_q_values() -> None:
+    """Ensure the social kernel updates both self and demonstrator actions.
+
+    Returns
+    -------
+    None
+        This test asserts both update paths.
+    """
+
+    kernel = SocialObservedOutcomeQKernel()
+    params = kernel.parse_params({"alpha_self": 0.0, "alpha_other": 0.0, "beta": 1.0})
+    state = kernel.initial_state(2, params)
+    view = DecisionTrialView(
+        trial_index=0,
+        available_actions=(0, 1),
+        choice=0,
+        reward=1.0,
+        social_action=1,
+        social_reward=0.0,
+    )
+
+    next_state = kernel.next_state(state, view, params)
+
+    assert next_state.q_values[0] > 0.5
+    assert next_state.q_values[1] < 0.5


### PR DESCRIPTION
## Summary
- add asocial Q-learning and social observed-outcome Q-learning kernels
- wire kernel metadata exports through the models package
- add behavior tests for probability and learning updates