### PR TITLE
Phase 10: Add inference config and dispatch

### DIFF
--- a/src/comp_model/inference/__init__.py
+++ b/src/comp_model/inference/__init__.py
@@ -1,1 +1,6 @@
 """Inference backends and configuration."""
+
+from comp_model.inference.config import HierarchyStructure, InferenceConfig
+from comp_model.inference.dispatch import fit
+
+__all__ = ["HierarchyStructure", "InferenceConfig", "fit"]

--- a/src/comp_model/inference/config.py
+++ b/src/comp_model/inference/config.py
@@ -1,0 +1,42 @@
+"""Shared inference configuration types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from comp_model.inference.mle.optimize import MleOptimizerConfig
+
+
+class HierarchyStructure(StrEnum):
+    """Supported pooling structures for inference backends."""
+
+    SUBJECT_SHARED = "subject_shared"
+    SUBJECT_BLOCK_CONDITION = "subject_block_condition_hierarchy"
+    STUDY_SUBJECT = "study_subject_hierarchy"
+    STUDY_SUBJECT_BLOCK_CONDITION = "study_subject_block_condition_hierarchy"
+
+
+@dataclass(frozen=True, slots=True)
+class InferenceConfig:
+    """Configuration for dispatching model fits.
+
+    Attributes
+    ----------
+    hierarchy
+        Pooling structure used by the requested backend.
+    backend
+        Inference backend identifier.
+    sampler
+        Sampler or optimizer identifier within the backend.
+    mle_config
+        Configuration for MLE optimization.
+    stan_config
+        Optional backend-specific Stan configuration.
+    """
+
+    hierarchy: HierarchyStructure
+    backend: str = "stan"
+    sampler: str = "nuts"
+    mle_config: MleOptimizerConfig = field(default_factory=MleOptimizerConfig)
+    stan_config: object | None = None

--- a/src/comp_model/inference/dispatch.py
+++ b/src/comp_model/inference/dispatch.py
@@ -1,0 +1,68 @@
+"""Unified inference dispatch entry point."""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any, cast
+
+from comp_model.data.schema import Dataset, SubjectData
+from comp_model.inference.mle.optimize import MleFitResult, fit_mle_conditioned, fit_mle_simple
+
+if TYPE_CHECKING:
+    from comp_model.inference.config import InferenceConfig
+    from comp_model.models.condition.shared_delta import SharedDeltaLayout
+    from comp_model.models.kernels.base import ModelKernel
+    from comp_model.tasks.schemas import TrialSchema
+
+
+def fit(
+    config: InferenceConfig,
+    kernel: ModelKernel[object, object],
+    data: SubjectData | Dataset,
+    schema: TrialSchema,
+    layout: SharedDeltaLayout | None = None,
+    adapter: object | None = None,
+) -> MleFitResult | object:
+    """Dispatch a fit request to the configured inference backend.
+
+    Parameters
+    ----------
+    config
+        Inference configuration describing the requested backend.
+    kernel
+        Model kernel being fit.
+    data
+        Subject-level or dataset-level data.
+    schema
+        Trial schema used for replay extraction.
+    layout
+        Optional condition-aware parameter layout.
+    adapter
+        Optional backend-specific adapter for Stan inference.
+
+    Returns
+    -------
+    MleFitResult | object
+        Fit result for the selected backend.
+    """
+
+    if config.backend == "mle":
+        if not isinstance(data, SubjectData):
+            raise ValueError("MLE currently supports single-subject fitting only")
+        if layout is not None:
+            return fit_mle_conditioned(kernel, layout, data, schema, config.mle_config)
+        return fit_mle_simple(kernel, data, schema, config.mle_config)
+
+    if config.backend == "stan":
+        if adapter is None:
+            raise ValueError("Stan backend requires a StanAdapter")
+
+        stan_backend = cast(
+            "Any",
+            importlib.import_module("comp_model.inference.bayes.stan.backend"),
+        )
+        fit_stan = stan_backend.fit_stan
+
+        return fit_stan(adapter, data, schema, config.hierarchy, layout, config.stan_config)
+
+    raise ValueError(f"Unknown backend: {config.backend!r}")

--- a/tests/test_inference/test_dispatch.py
+++ b/tests/test_inference/test_dispatch.py
@@ -1,0 +1,179 @@
+"""Tests for inference configuration and dispatch."""
+
+from comp_model.data.schema import Dataset
+from comp_model.environments.bandit import StationaryBanditEnvironment
+from comp_model.inference.config import HierarchyStructure, InferenceConfig
+from comp_model.inference.dispatch import fit
+from comp_model.inference.mle.optimize import MleFitResult
+from comp_model.models.condition.shared_delta import SharedDeltaLayout
+from comp_model.models.kernels.asocial_q_learning import AsocialQLearningKernel
+from comp_model.runtime.engine import SimulationConfig, simulate_subject
+from comp_model.tasks.schemas import ASOCIAL_BANDIT_SCHEMA
+from comp_model.tasks.spec import BlockSpec, TaskSpec
+
+
+def _single_subject() -> object:
+    """Create a simulated single-subject dataset fixture.
+
+    Returns
+    -------
+    object
+        Simulated subject data for dispatch tests.
+    """
+
+    kernel = AsocialQLearningKernel()
+    return simulate_subject(
+        task=TaskSpec(
+            task_id="dispatch-simple",
+            blocks=(
+                BlockSpec(
+                    condition="baseline",
+                    n_trials=4,
+                    schema=ASOCIAL_BANDIT_SCHEMA,
+                    metadata={"n_actions": 2},
+                ),
+            ),
+        ),
+        env=StationaryBanditEnvironment(n_actions=2, reward_probs=(0.8, 0.2)),
+        kernel=kernel,
+        params=kernel.parse_params({"alpha": 0.0, "beta": 1.0}),
+        config=SimulationConfig(seed=11),
+        subject_id="s1",
+    )
+
+
+def _two_condition_task() -> TaskSpec:
+    """Create a two-block task with distinct conditions.
+
+    Returns
+    -------
+    TaskSpec
+        Two-condition task for conditioned dispatch tests.
+    """
+
+    return TaskSpec(
+        task_id="dispatch-conditioned",
+        blocks=(
+            BlockSpec(
+                condition="baseline",
+                n_trials=6,
+                schema=ASOCIAL_BANDIT_SCHEMA,
+                metadata={"n_actions": 2},
+            ),
+            BlockSpec(
+                condition="social",
+                n_trials=6,
+                schema=ASOCIAL_BANDIT_SCHEMA,
+                metadata={"n_actions": 2},
+            ),
+        ),
+    )
+
+
+def test_inference_config_defaults_match_expected_backend_settings() -> None:
+    """Ensure inference config defaults match the planning contract.
+
+    Returns
+    -------
+    None
+        This test asserts configuration defaults.
+    """
+
+    config = InferenceConfig(hierarchy=HierarchyStructure.SUBJECT_SHARED)
+
+    assert config.backend == "stan"
+    assert config.sampler == "nuts"
+
+
+def test_dispatch_routes_mle_simple_fits() -> None:
+    """Ensure dispatch routes simple MLE fits through the MLE backend.
+
+    Returns
+    -------
+    None
+        This test asserts the returned fit result type.
+    """
+
+    kernel = AsocialQLearningKernel()
+    subject = _single_subject()
+    result = fit(
+        InferenceConfig(
+            hierarchy=HierarchyStructure.SUBJECT_SHARED,
+            backend="mle",
+        ),
+        kernel,
+        subject,
+        ASOCIAL_BANDIT_SCHEMA,
+    )
+
+    assert isinstance(result, MleFitResult)
+    assert result.subject_id == "s1"
+
+
+def test_dispatch_rejects_dataset_for_mle_backend() -> None:
+    """Ensure MLE dispatch rejects dataset-level fits.
+
+    Returns
+    -------
+    None
+        This test raises on unsupported MLE data scope.
+    """
+
+    kernel = AsocialQLearningKernel()
+    subject = _single_subject()
+    dataset = Dataset(subjects=(subject,))
+
+    try:
+        fit(
+            InferenceConfig(
+                hierarchy=HierarchyStructure.SUBJECT_SHARED,
+                backend="mle",
+            ),
+            kernel,
+            dataset,
+            ASOCIAL_BANDIT_SCHEMA,
+        )
+    except ValueError as exc:
+        assert "single-subject" in str(exc)
+    else:
+        raise AssertionError("Expected MLE dispatch to reject dataset-level data")
+
+
+def test_dispatch_routes_conditioned_mle_fits() -> None:
+    """Ensure dispatch routes conditioned MLE fits when a layout is provided.
+
+    Returns
+    -------
+    None
+        This test asserts conditioned fit metadata exists.
+    """
+
+    kernel = AsocialQLearningKernel()
+    params = kernel.parse_params({"alpha": 0.0, "beta": 1.0})
+    subject = simulate_subject(
+        task=_two_condition_task(),
+        env=StationaryBanditEnvironment(n_actions=2, reward_probs=(0.8, 0.2)),
+        kernel=kernel,
+        params=params,
+        config=SimulationConfig(seed=7),
+        subject_id="s1",
+    )
+    layout = SharedDeltaLayout(
+        kernel_spec=kernel.spec(),
+        conditions=("baseline", "social"),
+        baseline_condition="baseline",
+    )
+
+    result = fit(
+        InferenceConfig(
+            hierarchy=HierarchyStructure.SUBJECT_BLOCK_CONDITION,
+            backend="mle",
+        ),
+        kernel,
+        subject,
+        ASOCIAL_BANDIT_SCHEMA,
+        layout=layout,
+    )
+
+    assert isinstance(result, MleFitResult)
+    assert result.params_by_condition is not None


### PR DESCRIPTION
## Summary
- add hierarchy and backend configuration types for inference requests
- add the unified fit dispatch entry point for MLE and future Stan backends
- add dispatch tests for simple, conditioned, and invalid MLE routes