### PR TITLE
Phase 13: Add Stan backend

### DIFF
--- a/src/comp_model/inference/bayes/__init__.py
+++ b/src/comp_model/inference/bayes/__init__.py
@@ -1,1 +1,5 @@
 """Bayesian inference backends and results."""
+
+from comp_model.inference.bayes.result import BayesFitResult
+
+__all__ = ["BayesFitResult"]

--- a/src/comp_model/inference/bayes/result.py
+++ b/src/comp_model/inference/bayes/result.py
@@ -1,0 +1,39 @@
+"""Bayesian fit result containers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from comp_model.inference.config import HierarchyStructure
+
+
+@dataclass(frozen=True, slots=True)
+class BayesFitResult:
+    """Posterior samples and diagnostics returned by a Bayesian fit.
+
+    Attributes
+    ----------
+    model_id
+        Identifier of the fitted model.
+    hierarchy
+        Hierarchy structure used for the fit.
+    posterior_samples
+        Posterior draws keyed by parameter name.
+    log_lik
+        Trialwise log-likelihood draws.
+    subject_params
+        Optional per-subject posterior draws for hierarchical models.
+    diagnostics
+        Backend diagnostics and summaries.
+    """
+
+    model_id: str
+    hierarchy: HierarchyStructure
+    posterior_samples: dict[str, np.ndarray]
+    log_lik: np.ndarray
+    subject_params: dict[str, dict[str, np.ndarray]] | None
+    diagnostics: dict[str, Any]

--- a/src/comp_model/inference/bayes/stan/backend.py
+++ b/src/comp_model/inference/bayes/stan/backend.py
@@ -1,0 +1,115 @@
+"""CmdStanPy-backed Bayesian fitting."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+import numpy as np
+
+from comp_model.inference.bayes.result import BayesFitResult
+
+if TYPE_CHECKING:
+    from comp_model.data.schema import Dataset, SubjectData
+    from comp_model.inference.bayes.stan.adapters.base import StanAdapter
+    from comp_model.inference.config import HierarchyStructure
+    from comp_model.models.condition.shared_delta import SharedDeltaLayout
+    from comp_model.tasks.schemas import TrialSchema
+
+
+@dataclass(frozen=True, slots=True)
+class StanFitConfig:
+    """Configuration for Stan NUTS sampling.
+
+    Attributes
+    ----------
+    n_warmup
+        Number of warmup iterations per chain.
+    n_samples
+        Number of post-warmup samples per chain.
+    n_chains
+        Number of sampling chains.
+    seed
+        Optional random seed.
+    adapt_delta
+        Stan NUTS target acceptance rate.
+    max_treedepth
+        Maximum NUTS tree depth.
+    """
+
+    n_warmup: int = 1000
+    n_samples: int = 1000
+    n_chains: int = 4
+    seed: int | None = None
+    adapt_delta: float = 0.8
+    max_treedepth: int = 10
+
+
+DEFAULT_STAN_FIT_CONFIG = StanFitConfig()
+
+
+def fit_stan(
+    adapter: StanAdapter,
+    data: SubjectData | Dataset,
+    schema: TrialSchema,
+    hierarchy: HierarchyStructure,
+    layout: SharedDeltaLayout | None = None,
+    config: StanFitConfig | None = None,
+) -> BayesFitResult:
+    """Fit a model with Stan using the supplied adapter and data.
+
+    Parameters
+    ----------
+    adapter
+        Stan adapter that provides data and program paths.
+    data
+        Subject or dataset to fit.
+    schema
+        Trial schema used for replay extraction.
+    hierarchy
+        Hierarchy structure targeted by the Stan program.
+    layout
+        Optional condition-aware parameter layout.
+    config
+        Optional Stan sampling configuration.
+
+    Returns
+    -------
+    BayesFitResult
+        Posterior samples and diagnostics from the Stan fit.
+    """
+
+    resolved_config = config if config is not None else DEFAULT_STAN_FIT_CONFIG
+    cmdstanpy = cast("Any", importlib.import_module("cmdstanpy"))
+    model = cmdstanpy.CmdStanModel(stan_file=adapter.stan_program_path(hierarchy))
+    fit = model.sample(
+        data=adapter.build_stan_data(data, schema, hierarchy, layout),
+        iter_warmup=resolved_config.n_warmup,
+        iter_sampling=resolved_config.n_samples,
+        chains=resolved_config.n_chains,
+        seed=resolved_config.seed,
+        adapt_delta=resolved_config.adapt_delta,
+        max_treedepth=resolved_config.max_treedepth,
+    )
+
+    posterior_samples = {}
+    for parameter_name in adapter.subject_param_names():
+        posterior_samples[parameter_name] = np.asarray(fit.stan_variable(parameter_name))
+    for parameter_name in adapter.population_param_names(hierarchy):
+        posterior_samples[parameter_name] = np.asarray(fit.stan_variable(parameter_name))
+
+    log_lik = np.asarray(fit.stan_variable("log_lik"))
+    diagnostics = {
+        "n_divergences": int(fit.diagnose().count("divergent")),
+        "summary": fit.summary(),
+    }
+
+    return BayesFitResult(
+        model_id=adapter.kernel_spec().model_id,
+        hierarchy=hierarchy,
+        posterior_samples=posterior_samples,
+        log_lik=log_lik,
+        subject_params=None,
+        diagnostics=diagnostics,
+    )

--- a/src/comp_model/inference/dispatch.py
+++ b/src/comp_model/inference/dispatch.py
@@ -9,6 +9,7 @@ from comp_model.data.schema import Dataset, SubjectData
 from comp_model.inference.mle.optimize import MleFitResult, fit_mle_conditioned, fit_mle_simple
 
 if TYPE_CHECKING:
+    from comp_model.inference.bayes.result import BayesFitResult
     from comp_model.inference.config import InferenceConfig
     from comp_model.models.condition.shared_delta import SharedDeltaLayout
     from comp_model.models.kernels.base import ModelKernel
@@ -22,7 +23,7 @@ def fit(
     schema: TrialSchema,
     layout: SharedDeltaLayout | None = None,
     adapter: object | None = None,
-) -> MleFitResult | object:
+) -> MleFitResult | BayesFitResult:
     """Dispatch a fit request to the configured inference backend.
 
     Parameters

--- a/tests/test_inference/test_stan_backend.py
+++ b/tests/test_inference/test_stan_backend.py
@@ -1,0 +1,81 @@
+"""Tests for Stan backend configuration and error routing."""
+
+from comp_model.environments.bandit import StationaryBanditEnvironment
+from comp_model.inference.bayes.stan.backend import StanFitConfig
+from comp_model.inference.config import HierarchyStructure, InferenceConfig
+from comp_model.inference.dispatch import fit
+from comp_model.models.kernels.asocial_q_learning import AsocialQLearningKernel
+from comp_model.runtime.engine import SimulationConfig, simulate_subject
+from comp_model.tasks.schemas import ASOCIAL_BANDIT_SCHEMA
+from comp_model.tasks.spec import BlockSpec, TaskSpec
+
+
+def _subject() -> object:
+    """Create a simulated subject for Stan backend dispatch tests.
+
+    Returns
+    -------
+    object
+        Simulated subject data.
+    """
+
+    kernel = AsocialQLearningKernel()
+    return simulate_subject(
+        task=TaskSpec(
+            task_id="stan-dispatch",
+            blocks=(
+                BlockSpec(
+                    condition="baseline",
+                    n_trials=4,
+                    schema=ASOCIAL_BANDIT_SCHEMA,
+                    metadata={"n_actions": 2},
+                ),
+            ),
+        ),
+        env=StationaryBanditEnvironment(n_actions=2, reward_probs=(0.8, 0.2)),
+        kernel=kernel,
+        params=kernel.parse_params({"alpha": 0.0, "beta": 1.0}),
+        config=SimulationConfig(seed=31),
+        subject_id="s1",
+    )
+
+
+def test_stan_fit_config_defaults_match_expected_sampling_values() -> None:
+    """Ensure Stan fit config defaults match the implementation plan.
+
+    Returns
+    -------
+    None
+        This test asserts default sampler settings.
+    """
+
+    config = StanFitConfig()
+
+    assert config.n_warmup == 1000
+    assert config.n_samples == 1000
+    assert config.n_chains == 4
+
+
+def test_dispatch_rejects_stan_backend_without_adapter() -> None:
+    """Ensure Stan dispatch requires an adapter before sampling.
+
+    Returns
+    -------
+    None
+        This test raises on missing Stan adapter input.
+    """
+
+    kernel = AsocialQLearningKernel()
+    subject = _subject()
+
+    try:
+        fit(
+            InferenceConfig(hierarchy=HierarchyStructure.SUBJECT_SHARED, backend="stan"),
+            kernel,
+            subject,
+            ASOCIAL_BANDIT_SCHEMA,
+        )
+    except ValueError as exc:
+        assert "StanAdapter" in str(exc)
+    else:
+        raise AssertionError("Expected Stan dispatch to require an adapter")


### PR DESCRIPTION
## Summary
- add the Bayesian fit result container and Stan fit configuration
- add a lazy CmdStanPy backend entry point that samples and extracts draws
- add backend tests covering configuration defaults and Stan dispatch validation