### PR TITLE
Add missing NumPy-style optimizer docstrings

### DIFF
--- a/src/comp_model/data/extractors.py
+++ b/src/comp_model/data/extractors.py
@@ -1,4 +1,9 @@
-"""Schema-driven extraction from event traces to model-facing decision views."""
+"""Schema-driven extraction from event traces to model-facing decision views.
+
+This module bridges the canonical event hierarchy and backend-agnostic model
+kernels. Extraction is positional and schema-specific, while the resulting
+decision views are flat and order-agnostic.
+"""
 
 from __future__ import annotations
 
@@ -36,6 +41,13 @@ class DecisionTrialView:
         Observed demonstrator reward, if present.
     metadata
         Additional extractor metadata.
+
+    Notes
+    -----
+    Kernels consume :class:`DecisionTrialView` rather than :class:`Event`,
+    :class:`Trial`, or :class:`TrialSchema`. This allows the same kernel to work
+    with different event orders as long as the extractor produces the same flat
+    fields.
     """
 
     trial_index: int
@@ -62,6 +74,26 @@ def extract_decision_views(trial: Trial, schema: TrialSchema) -> tuple[DecisionT
     -------
     tuple[DecisionTrialView, ...]
         One flat record for each decision step in the schema.
+
+    Notes
+    -----
+    The extraction algorithm follows the implementation plan directly:
+
+    1. validate the trial against ``schema``,
+    2. iterate over each DECISION step declared by the schema,
+    3. scan the whole trial positionally to find the matching subject INPUT,
+       any demonstrator INPUT, and the OUTCOME linked by ``node_id``, and
+    4. emit one order-agnostic :class:`DecisionTrialView` for that decision.
+
+    ``node_id`` is only used for structural linking between a decision and its
+    outcome. Social information is detected from the schema's ``actor_id``
+    rather than from special node-name conventions.
+
+    Raises
+    ------
+    ValueError
+        Raised when the schema is violated or when no subject INPUT can be
+        found for a declared decision step.
     """
 
     schema.validate_trial(trial)

--- a/src/comp_model/data/schema.py
+++ b/src/comp_model/data/schema.py
@@ -1,4 +1,10 @@
-"""Canonical hierarchical data structures for the modeling package."""
+"""Canonical hierarchical data structures for the modeling package.
+
+The repository-wide source of truth is the event hierarchy
+``Event -> Trial -> Block -> SubjectData -> Dataset``. Simulation,
+validation, replay likelihoods, and Stan export all work from these objects
+rather than from a separate flattened table representation.
+"""
 
 from __future__ import annotations
 
@@ -25,6 +31,12 @@ class EventPhase(StrEnum):
         Scalar outcome associated with a decision point.
     UPDATE
         Explicit learning/update marker for the modeled agent.
+
+    Notes
+    -----
+    The phase vocabulary is intentionally generic. Task-specific semantics such as
+    "social observation before choice" are encoded by event order, ``actor_id``,
+    and ``node_id``, not by introducing task-specific phase enums.
     """
 
     INPUT = "input"
@@ -49,6 +61,13 @@ class Event:
         Identifier for the actor associated with the event.
     payload
         Phase-specific data carried by the event.
+
+    Notes
+    -----
+    ``node_id`` is structural rather than semantic. It links the INPUT,
+    DECISION, OUTCOME, and UPDATE events that belong to the same decision point
+    without requiring hard-coded domain labels such as ``"social"`` or
+    ``"stimulus"``.
     """
 
     phase: EventPhase
@@ -70,6 +89,11 @@ class Trial:
         Ordered events emitted during the trial.
     metadata
         Optional trial-level metadata.
+
+    Notes
+    -----
+    Trials do not include synthetic ``BLOCK_START`` or ``BLOCK_END`` events.
+    Block boundaries are represented explicitly by :class:`Block`.
     """
 
     trial_index: int
@@ -91,6 +115,11 @@ class Block:
         Ordered trials belonging to the block.
     metadata
         Optional block-level metadata.
+
+    Notes
+    -----
+    A block is the structural unit that determines condition changes and, when a
+    kernel opts into ``state_reset_policy="per_block"``, latent-state resets.
     """
 
     block_index: int
@@ -111,6 +140,11 @@ class SubjectData:
         Ordered blocks completed by the subject.
     metadata
         Optional subject-level metadata.
+
+    Notes
+    -----
+    The order of ``blocks`` is semantically important. Replay and simulation
+    assume it reflects the real sequence experienced by the subject.
     """
 
     subject_id: str
@@ -123,7 +157,8 @@ class SubjectData:
         Yields
         ------
         tuple[Block, Trial]
-            Each block-trial pair in hierarchical order.
+            Each block-trial pair in hierarchical order, preserving the exact
+            replay order used by likelihood code.
         """
 
         for block in self.blocks:
@@ -137,7 +172,8 @@ class SubjectData:
         Returns
         -------
         tuple[Trial, ...]
-            Trial records in block order.
+            Trial records in block order. This is a convenience view rather than
+            the primary ontology.
         """
 
         return tuple(trial for block in self.blocks for trial in block.trials)
@@ -153,6 +189,11 @@ class Dataset:
         Ordered subject records in the dataset.
     metadata
         Optional dataset-level metadata.
+
+    Notes
+    -----
+    Dataset-level helper properties preserve subject-major ordering so that
+    downstream exporters can reconstruct subject and block indices deterministically.
     """
 
     subjects: tuple[SubjectData, ...]
@@ -165,7 +206,7 @@ class Dataset:
         Returns
         -------
         tuple[Block, ...]
-            Blocks in subject order.
+            Blocks in subject-major order.
         """
 
         return tuple(block for subject in self.subjects for block in subject.blocks)
@@ -177,7 +218,7 @@ class Dataset:
         Returns
         -------
         tuple[Trial, ...]
-            Trials in dataset order.
+            Trials in subject-major, then block-major order.
         """
 
         return tuple(

--- a/src/comp_model/data/validation.py
+++ b/src/comp_model/data/validation.py
@@ -1,4 +1,9 @@
-"""Validation helpers for canonical event-based data structures."""
+"""Validation helpers for canonical event-based data structures.
+
+The validation layer checks the structural contracts of the canonical hierarchy
+without introducing task-specific semantics. When a trial schema is supplied,
+schema validation becomes the stricter source of truth for positional meaning.
+"""
 
 from __future__ import annotations
 
@@ -14,7 +19,7 @@ class _TrialSchemaProtocol(Protocol):
     Methods
     -------
     validate_trial(trial)
-        Validate a trial against an external schema.
+        Validate a trial against an external schema implementation.
     """
 
     def validate_trial(self, trial: Trial) -> None:
@@ -48,6 +53,16 @@ def validate_event_payload(event: Event, trial_index: int, step_index: int) -> N
     -------
     None
         This function raises on invalid payloads.
+
+    Notes
+    -----
+    Payload validation is phase-specific:
+
+    - INPUT requires ``available_actions``,
+    - DECISION requires ``action``, and
+    - OUTCOME requires ``reward``.
+
+    UPDATE currently has no required payload keys.
     """
 
     prefix = f"Trial {trial_index}, event {step_index}"
@@ -83,6 +98,12 @@ def validate_event(event: Event, trial_index: int, step_index: int) -> None:
     -------
     None
         This function raises on invalid events.
+
+    Notes
+    -----
+    This check is intentionally local to one event. It enforces non-empty
+    ``node_id`` and ``actor_id``, verifies ``event_index`` matches the event's
+    position, and then delegates payload checks to :func:`validate_event_payload`.
     """
 
     if not event.node_id or not event.node_id.strip():
@@ -111,6 +132,13 @@ def validate_trial(trial: Trial, schema: _TrialSchemaProtocol | None = None) -> 
     -------
     None
         This function raises on invalid trials.
+
+    Notes
+    -----
+    Without a schema, trial validation only enforces generic structural rules
+    such as contiguous event indices. With a schema, the schema takes over
+    positional validation so that phase order, actor identity, node identity,
+    and payload requirements all come from the same declarative contract.
     """
 
     if schema is not None:
@@ -143,6 +171,11 @@ def validate_block(block: Block, schema: _TrialSchemaProtocol | None = None) -> 
     -------
     None
         This function raises on invalid blocks.
+
+    Notes
+    -----
+    Block validation checks the block's own condition label and trial-index
+    contiguity before delegating trial validation to :func:`validate_trial`.
     """
 
     if not block.condition or not block.condition.strip():
@@ -172,6 +205,11 @@ def validate_subject(subject: SubjectData, schema: _TrialSchemaProtocol | None =
     -------
     None
         This function raises on invalid subject data.
+
+    Notes
+    -----
+    Subject validation enforces subject ID presence, contiguous block ordering,
+    and recursive validation of every block in subject order.
     """
 
     if not subject.subject_id or not subject.subject_id.strip():
@@ -201,6 +239,12 @@ def validate_dataset(dataset: Dataset, schema: _TrialSchemaProtocol | None = Non
     -------
     None
         This function raises on invalid datasets.
+
+    Notes
+    -----
+    Dataset validation currently checks for unique subject IDs and then validates
+    every subject independently. It does not impose cross-subject task-equality
+    constraints.
     """
 
     subject_ids = [subject.subject_id for subject in dataset.subjects]

--- a/src/comp_model/environments/bandit.py
+++ b/src/comp_model/environments/bandit.py
@@ -1,4 +1,8 @@
-"""Concrete stationary bandit environment."""
+"""Concrete stationary bandit environment.
+
+This environment executes the current trial schema one step at a time while
+sampling Bernoulli rewards from fixed arm probabilities.
+"""
 
 from __future__ import annotations
 
@@ -16,7 +20,14 @@ if TYPE_CHECKING:
 
 @dataclass(slots=True)
 class StationaryBanditEnvironment:
-    """Simple k-armed bandit with fixed reward probabilities."""
+    """Simple k-armed bandit with fixed reward probabilities.
+
+    Notes
+    -----
+    The environment is intentionally schema-agnostic beyond the current step's
+    declared phase. It can therefore execute any schema whose steps follow the
+    INPUT/DECISION/OUTCOME/UPDATE contract expected by the runtime.
+    """
 
     n_actions: int
     reward_probs: tuple[float, ...]
@@ -52,6 +63,12 @@ class StationaryBanditEnvironment:
         -------
         None
             This function resets the environment in-place.
+
+        Notes
+        -----
+        Reset clears step and trial counters, stores the block specification,
+        and binds the random generator that will be used for stochastic outcome
+        sampling throughout the block.
         """
 
         self._block_spec = block_spec
@@ -72,6 +89,15 @@ class StationaryBanditEnvironment:
         -------
         tuple[Event, ...]
             Events emitted for the current step.
+
+        Notes
+        -----
+        The emitted event is determined purely by the current schema step:
+
+        - INPUT emits legal actions and a simple observation payload,
+        - DECISION records the externally supplied action,
+        - OUTCOME samples a Bernoulli reward from ``reward_probs[action]``, and
+        - UPDATE emits an explicit update marker.
         """
 
         if self._block_spec is None or self._rng is None:
@@ -149,6 +175,12 @@ class StationaryBanditEnvironment:
         -------
         None
             This function mutates the environment in-place.
+
+        Notes
+        -----
+        Advancing wraps the step counter to zero at the end of the schema,
+        increments the trial counter, and clears the cached last action so the
+        next trial must begin with a fresh decision sequence.
         """
 
         n_steps = len(schema.steps)

--- a/src/comp_model/environments/base.py
+++ b/src/comp_model/environments/base.py
@@ -1,4 +1,8 @@
-"""Environment protocol for executable task dynamics."""
+"""Environment protocol for executable task dynamics.
+
+Environments execute the task layer one schema step at a time and emit events
+that satisfy the current :class:`~comp_model.tasks.schemas.TrialSchema`.
+"""
 
 from __future__ import annotations
 
@@ -12,7 +16,14 @@ if TYPE_CHECKING:
 
 
 class Environment(Protocol):
-    """Protocol implemented by executable environments."""
+    """Protocol implemented by executable environments.
+
+    Notes
+    -----
+    The runtime owns the outer loop over blocks, trials, and agent decisions.
+    The environment owns only task-side dynamics: resetting block state and
+    emitting one or more events for the next schema position.
+    """
 
     @property
     def environment_id(self) -> str:
@@ -40,6 +51,12 @@ class Environment(Protocol):
         -------
         None
             This function resets the environment in-place.
+
+        Notes
+        -----
+        ``reset`` is called once per block before any trials in that block are
+        executed. It should bind the block specification and discard any prior
+        within-block state.
         """
 
         ...
@@ -56,6 +73,12 @@ class Environment(Protocol):
         -------
         tuple[Event, ...]
             Events emitted for the current schema step.
+
+        Notes
+        -----
+        ``action`` is supplied only for schema steps whose
+        ``action_required`` flag is true. The environment is responsible for
+        converting that action into one or more canonical events.
         """
 
         ...

--- a/src/comp_model/inference/bayes/result.py
+++ b/src/comp_model/inference/bayes/result.py
@@ -29,6 +29,12 @@ class BayesFitResult:
         Optional per-subject posterior draws for hierarchical models.
     diagnostics
         Backend diagnostics and summaries.
+
+    Notes
+    -----
+    The container is backend-agnostic at the API level, but the current Stan
+    backend fills ``posterior_samples`` and ``log_lik`` directly from CmdStanPy
+    variables extracted from a completed fit.
     """
 
     model_id: str

--- a/src/comp_model/inference/bayes/stan/adapters/asocial_q_learning.py
+++ b/src/comp_model/inference/bayes/stan/adapters/asocial_q_learning.py
@@ -1,4 +1,8 @@
-"""Stan adapter for the asocial Q-learning kernel."""
+"""Stan adapter for the asocial Q-learning kernel.
+
+Adapters isolate Stan-specific choices such as program filenames, data export,
+and which posterior variables should be read back from a completed fit.
+"""
 
 from __future__ import annotations
 
@@ -23,7 +27,13 @@ if TYPE_CHECKING:
 
 
 class AsocialQLearningStanAdapter:
-    """Stan adapter for the asocial Q-learning kernel."""
+    """Stan adapter for the asocial Q-learning kernel.
+
+    Notes
+    -----
+    The adapter currently supports the asocial Q-learning family only and uses a
+    simple filename convention based on ``model_id`` and hierarchy name.
+    """
 
     def kernel_spec(self) -> ModelKernelSpec:
         """Return the kernel specification served by this adapter.
@@ -48,6 +58,12 @@ class AsocialQLearningStanAdapter:
         -------
         str
             Absolute path to the Stan program file.
+
+        Notes
+        -----
+        Program filenames follow
+        ``{model_id}__{hierarchy.value}.stan`` inside the adapter's sibling
+        ``programs`` directory.
         """
 
         programs_dir = Path(__file__).resolve().parent.parent / "programs"
@@ -78,6 +94,12 @@ class AsocialQLearningStanAdapter:
         -------
         dict[str, Any]
             Stan-ready data dictionary.
+
+        Notes
+        -----
+        The adapter always exports replay data, prior hyperparameters, and the
+        integer reset-policy flag. Condition indices are added only for
+        condition-aware hierarchies and only when fitting a single subject.
         """
 
         if isinstance(data, SubjectData):
@@ -105,7 +127,8 @@ class AsocialQLearningStanAdapter:
         Returns
         -------
         tuple[str, ...]
-            Subject-level parameter names.
+            Subject-level parameter names expected in the Stan generated
+            quantities or transformed parameters blocks.
         """
 
         return ("alpha", "beta")
@@ -121,7 +144,8 @@ class AsocialQLearningStanAdapter:
         Returns
         -------
         tuple[str, ...]
-            Population-level parameter names.
+            Population-level parameter names. Subject-shared fits have no
+            separate population-level outputs.
         """
 
         if hierarchy == HierarchyStructure.SUBJECT_SHARED:

--- a/src/comp_model/inference/bayes/stan/backend.py
+++ b/src/comp_model/inference/bayes/stan/backend.py
@@ -1,4 +1,9 @@
-"""CmdStanPy-backed Bayesian fitting."""
+"""CmdStanPy-backed Bayesian fitting.
+
+The Stan backend compiles the program selected by an adapter, delegates data
+construction to the adapter, and translates a completed CmdStanPy fit into the
+package's backend-agnostic result container.
+"""
 
 from __future__ import annotations
 
@@ -36,6 +41,11 @@ class StanFitConfig:
         Stan NUTS target acceptance rate.
     max_treedepth
         Maximum NUTS tree depth.
+
+    Notes
+    -----
+    These fields are passed through to ``CmdStanModel.sample`` with matching
+    names where possible.
     """
 
     n_warmup: int = 1000
@@ -78,6 +88,12 @@ def fit_stan(
     -------
     BayesFitResult
         Posterior samples and diagnostics from the Stan fit.
+
+    Notes
+    -----
+    The backend imports CmdStanPy lazily so the package can be imported without
+    Stan installed. The adapter determines both the Stan program path and the
+    exact data dictionary to pass into sampling.
     """
 
     resolved_config = config if config is not None else DEFAULT_STAN_FIT_CONFIG

--- a/src/comp_model/inference/bayes/stan/data_builder.py
+++ b/src/comp_model/inference/bayes/stan/data_builder.py
@@ -1,4 +1,9 @@
-"""Stan data builders for event-based subject and dataset structures."""
+"""Stan data builders for event-based subject and dataset structures.
+
+The Stan exporter is a derived view over the canonical event hierarchy. It does
+not define the primary ontology; it flattens extracted decision views into the
+array layout expected by the Stan programs.
+"""
 
 from __future__ import annotations
 
@@ -30,6 +35,14 @@ def subject_to_stan_data(subject_data: SubjectData, schema: TrialSchema) -> dict
     -------
     dict[str, Any]
         Stan-ready flat arrays with contiguous 1-based action indexing.
+
+    Notes
+    -----
+    The exporter iterates over blocks and trials in observed order, extracts
+    :class:`~comp_model.data.extractors.DecisionTrialView` records, remaps any
+    raw action identifiers to contiguous 1-based Stan indices, and emits arrays
+    aligned trial-by-trial for choice, reward, availability mask, block index,
+    and optional social information.
     """
 
     trials_flat: list[DecisionTrialView] = []
@@ -94,6 +107,12 @@ def dataset_to_stan_data(dataset: Dataset, schema: TrialSchema) -> dict[str, Any
     -------
     dict[str, Any]
         Stan-ready hierarchical arrays with subject indexing.
+
+    Notes
+    -----
+    Dataset export is implemented by first exporting each subject independently
+    with :func:`subject_to_stan_data`, then concatenating those subject chunks in
+    subject-major order while adding a 1-based ``subj`` index.
     """
 
     subject_chunks = [subject_to_stan_data(subject, schema) for subject in dataset.subjects]
@@ -157,6 +176,12 @@ def add_condition_data(
     -------
     None
         This function mutates ``stan_data`` in-place.
+
+    Notes
+    -----
+    Condition IDs are assigned in ``layout.conditions`` order. The baseline
+    condition is exported separately so Stan programs can reconstruct
+    shared-plus-delta parameterizations consistently with Python.
     """
 
     condition_to_id = {
@@ -189,6 +214,12 @@ def add_prior_data(stan_data: dict[str, Any], kernel_spec: ModelKernelSpec) -> N
     -------
     None
         This function mutates ``stan_data`` in-place.
+
+    Notes
+    -----
+    Prior means and scales are exported on the unconstrained parameterization
+    used by the kernel specification. Parameters without an explicit prior fall
+    back to a weak ``Normal(0, 2)`` convention.
     """
 
     for parameter in kernel_spec.parameter_specs:
@@ -221,6 +252,11 @@ def add_state_reset_data(stan_data: dict[str, Any], kernel_spec: ModelKernelSpec
     ------
     ValueError
         Raised when the kernel exposes an unknown reset policy.
+
+    Notes
+    -----
+    Stan receives the reset policy as an integer flag because the compiled
+    program cannot inspect Python-side kernel metadata directly.
     """
 
     if kernel_spec.state_reset_policy == "per_subject":
@@ -244,6 +280,12 @@ def _action_index_mapping(trials_flat: Iterable[DecisionTrialView]) -> dict[int,
     -------
     dict[int, int]
         Mapping from raw action identifier to 1-based Stan index.
+
+    Notes
+    -----
+    Actions are assigned indices in first-seen order across available actions,
+    realized subject choices, and any observed social actions. This keeps Stan
+    arrays compact even when raw action IDs are sparse.
     """
 
     ordered_actions: list[int] = []

--- a/src/comp_model/inference/config.py
+++ b/src/comp_model/inference/config.py
@@ -13,7 +13,13 @@ if TYPE_CHECKING:
 
 
 class HierarchyStructure(StrEnum):
-    """Supported pooling structures for inference backends."""
+    """Supported pooling structures for inference backends.
+
+    Notes
+    -----
+    The enum names describe the intended parameter sharing pattern rather than
+    the mechanics of any one backend implementation.
+    """
 
     SUBJECT_SHARED = "subject_shared"
     SUBJECT_BLOCK_CONDITION = "subject_block_condition_hierarchy"
@@ -37,6 +43,12 @@ class InferenceConfig:
         Configuration for MLE optimization.
     stan_config
         Optional backend-specific Stan configuration.
+
+    Notes
+    -----
+    ``InferenceConfig`` selects the backend entry point only. Kernel semantics,
+    task semantics, and condition layouts are supplied separately so they can be
+    shared across MLE and Stan backends.
     """
 
     hierarchy: HierarchyStructure

--- a/src/comp_model/inference/dispatch.py
+++ b/src/comp_model/inference/dispatch.py
@@ -1,4 +1,8 @@
-"""Unified inference dispatch entry point."""
+"""Unified inference dispatch entry point.
+
+The dispatch layer chooses between backend implementations while preserving one
+shared kernel/task/data interface.
+"""
 
 from __future__ import annotations
 
@@ -45,6 +49,15 @@ def fit(
     -------
     MleFitResult | object
         Fit result for the selected backend.
+
+    Notes
+    -----
+    Dispatch enforces the current scope of each backend:
+
+    - MLE is single-subject only,
+    - conditioned MLE is selected when ``layout`` is provided, and
+    - the Stan backend requires an explicit adapter that knows how to build data
+      and select a Stan program for the requested hierarchy.
     """
 
     if config.backend == "mle":

--- a/src/comp_model/inference/mle/objective.py
+++ b/src/comp_model/inference/mle/objective.py
@@ -1,4 +1,8 @@
-"""Replay log-likelihood functions for maximum-likelihood estimation."""
+"""Replay log-likelihood functions for maximum-likelihood estimation.
+
+These functions replay observed event traces through a model kernel using the
+same extracted decision views used during simulation.
+"""
 
 from __future__ import annotations
 
@@ -37,6 +41,14 @@ def log_likelihood_simple(
     -------
     float
         Total log-likelihood across all decision views.
+
+    Notes
+    -----
+    Replay parses the unconstrained parameters once, initializes latent state,
+    loops over blocks and trials in observed order, and accumulates
+    ``log(p(choice))`` from the action-probability vector aligned to
+    ``view.available_actions``. Probabilities are clipped away from zero before
+    taking logs to avoid ``-inf`` from numerical underflow.
     """
 
     params = kernel.parse_params(raw_params)
@@ -76,6 +88,11 @@ def _infer_n_actions_from_data(subject_data: SubjectData) -> int:
     ------
     ValueError
         Raised when no INPUT event with available actions is found.
+
+    Notes
+    -----
+    This helper scans the observed data rather than trusting task metadata so
+    replay can work directly from canonical subject traces.
     """
 
     for block in subject_data.blocks:
@@ -118,6 +135,10 @@ def log_likelihood_conditioned(
     Conditioned replay changes parameters by block condition, but it still follows the
     kernel's state reset policy. With ``state_reset_policy="per_subject"``, latent
     state carries across condition boundaries within a subject.
+
+    For each block, the shared-plus-delta layout reconstructs that block's
+    unconstrained parameter vector before replay continues through the block's
+    trials.
     """
 
     reset_policy = kernel.spec().state_reset_policy

--- a/src/comp_model/inference/mle/optimize.py
+++ b/src/comp_model/inference/mle/optimize.py
@@ -1,4 +1,8 @@
-"""Scipy-based maximum-likelihood optimization utilities."""
+"""Scipy-based maximum-likelihood optimization utilities.
+
+MLE fitting is performed on the unconstrained parameter scale using SciPy's
+local optimizers and replay-based likelihood evaluation.
+"""
 
 from __future__ import annotations
 
@@ -37,6 +41,11 @@ class MleOptimizerConfig:
         Shared lower and upper bounds on unconstrained parameters.
     max_iter
         Maximum number of optimizer iterations.
+
+    Notes
+    -----
+    Restarts use one deterministic default start plus ``n_restarts - 1`` random
+    draws sampled uniformly inside ``z_bounds``.
     """
 
     method: str = "L-BFGS-B"
@@ -49,7 +58,41 @@ class MleOptimizerConfig:
 
 @dataclass(frozen=True, slots=True)
 class MleFitResult:
-    """Result bundle for a single-subject MLE fit."""
+    """Result bundle for a single-subject MLE fit.
+
+    Attributes
+    ----------
+    subject_id
+        Subject identifier whose data were fit.
+    model_id
+        Kernel identifier reported by :class:`~comp_model.models.kernels.base.ModelKernelSpec`.
+    log_likelihood
+        Best replay log-likelihood found across restarts.
+    n_params
+        Number of free unconstrained parameters optimized.
+    raw_params
+        Best-fitting unconstrained parameters.
+    constrained_params
+        Best-fitting constrained parameters. For conditioned fits this reports
+        the baseline condition's constrained parameters.
+    aic
+        Akaike information criterion computed from the winning fit.
+    bic
+        Bayesian information criterion computed from the winning fit.
+    n_trials
+        Number of observed trials contributing to the objective.
+    converged
+        Whether the winning SciPy run reported success.
+    n_restarts
+        Number of restart candidates evaluated.
+    all_candidates
+        Unconstrained parameter vectors returned by every restart.
+    all_log_likelihoods
+        Replay log-likelihood values corresponding to ``all_candidates``.
+    params_by_condition
+        Optional constrained parameters reconstructed per condition for
+        conditioned fits.
+    """
 
     subject_id: str
     model_id: str
@@ -93,6 +136,14 @@ def fit_mle_simple(
     -------
     MleFitResult
         Best fit found across all restart candidates.
+
+    Notes
+    -----
+    The optimizer minimizes the negative replay log-likelihood. The default
+    start comes from each parameter's ``mle_init.default_unconstrained`` when
+    available, followed by random restart points in ``config.z_bounds``. The
+    winning unconstrained solution is transformed back to the constrained
+    parameter space before reporting AIC and BIC.
     """
 
     scipy_optimize = cast("Any", importlib.import_module("scipy.optimize"))
@@ -130,6 +181,11 @@ def fit_mle_simple(
         float
             Negative log-likelihood objective for ``scipy.optimize.minimize``.
             Non-finite replay scores are converted to a large penalty value.
+
+        Notes
+        -----
+        Penalizing non-finite values keeps SciPy inside the search rather than
+        aborting when a restart wanders into a numerically unstable region.
         """
 
         raw_params = {name: float(value) for name, value in zip(param_names, z_vector, strict=True)}
@@ -222,6 +278,13 @@ def fit_mle_conditioned(
     -------
     MleFitResult
         Best fit found across all restart candidates.
+
+    Notes
+    -----
+    This routine mirrors :func:`fit_mle_simple`, but the optimized vector lives
+    in :class:`~comp_model.models.condition.shared_delta.SharedDeltaLayout`
+    order. After optimization, the winning vector is reconstructed separately
+    for each condition and transformed into constrained parameter values.
     """
 
     scipy_optimize = cast("Any", importlib.import_module("scipy.optimize"))
@@ -253,6 +316,11 @@ def fit_mle_conditioned(
         float
             Negative conditioned log-likelihood for ``scipy.optimize.minimize``.
             Non-finite replay scores are converted to a large penalty value.
+
+        Notes
+        -----
+        The conditioned objective differs from the simple objective only in how
+        the raw vector is interpreted before replay.
         """
 
         raw_params = {name: float(value) for name, value in zip(param_keys, z_vector, strict=True)}

--- a/src/comp_model/models/condition/shared_delta.py
+++ b/src/comp_model/models/condition/shared_delta.py
@@ -29,6 +29,9 @@ class SharedDeltaLayout:
     ``state_reset_policy="per_subject"``, state learned in one condition carries into
     the next condition within the same subject unless the kernel itself uses
     ``state_reset_policy="per_block"``.
+
+    Shared parameters are represented once, and each non-baseline condition gets
+    an additive delta on the unconstrained scale.
     """
 
     kernel_spec: ModelKernelSpec
@@ -57,7 +60,8 @@ class SharedDeltaLayout:
         Returns
         -------
         tuple[str, ...]
-            Shared keys followed by non-baseline delta keys.
+            Shared keys followed by non-baseline delta keys, both in kernel
+            parameter order.
         """
 
         keys: list[str] = []
@@ -76,7 +80,8 @@ class SharedDeltaLayout:
         Returns
         -------
         dict[str, float]
-            Zero-valued unconstrained parameter dictionary.
+            Zero-valued unconstrained parameter dictionary. A zero vector means
+            baseline and non-baseline conditions initially coincide.
         """
 
         return {key: 0.0 for key in self.parameter_keys()}
@@ -106,6 +111,12 @@ class SharedDeltaLayout:
         -------
         dict[str, float]
             Unconstrained kernel parameters keyed by parameter name.
+
+        Notes
+        -----
+        For the baseline condition, reconstruction returns only the shared
+        terms. For any other condition, reconstruction adds that condition's
+        delta term to each shared parameter on the unconstrained scale.
         """
 
         if condition not in self.conditions:
@@ -130,7 +141,8 @@ class SharedDeltaLayout:
         Returns
         -------
         dict[str, dict[str, float]]
-            Reconstructed unconstrained parameter dictionaries per condition.
+            Reconstructed unconstrained parameter dictionaries for every
+            condition in layout order.
         """
 
         return {condition: self.reconstruct(raw, condition) for condition in self.conditions}

--- a/src/comp_model/models/kernels/asocial_q_learning.py
+++ b/src/comp_model/models/kernels/asocial_q_learning.py
@@ -1,4 +1,8 @@
-"""Asocial Q-learning kernel."""
+"""Asocial Q-learning kernel.
+
+This kernel implements a standard Rescorla-Wagner update with softmax action
+selection over latent action values.
+"""
 
 from __future__ import annotations
 
@@ -43,7 +47,15 @@ class QState:
 
 
 class AsocialQLearningKernel:
-    """Standard softmax Q-learning kernel for asocial bandit tasks."""
+    """Standard softmax Q-learning kernel for asocial bandit tasks.
+
+    Notes
+    -----
+    The kernel is schema-agnostic. It relies only on the extracted
+    :class:`~comp_model.data.extractors.DecisionTrialView`, so the same kernel
+    can be replayed against any task schema that yields compatible asocial
+    decision views.
+    """
 
     @classmethod
     def spec(cls) -> ModelKernelSpec:
@@ -52,7 +64,9 @@ class AsocialQLearningKernel:
         Returns
         -------
         ModelKernelSpec
-            Static kernel specification.
+            Static kernel specification declaring two parameters:
+            ``alpha`` on the unit interval and ``beta`` on the positive real
+            line.
         """
 
         return ModelKernelSpec(
@@ -96,7 +110,7 @@ class AsocialQLearningKernel:
         Returns
         -------
         QParams
-            Typed parameter object.
+            Typed parameter object after applying the shared transform registry.
         """
 
         return QParams(
@@ -144,6 +158,13 @@ class AsocialQLearningKernel:
         -------
         tuple[float, ...]
             Probabilities aligned with ``view.available_actions``.
+
+        Notes
+        -----
+        The kernel scores only the currently legal actions, multiplies their
+        latent values by ``beta``, and normalizes them with a numerically stable
+        softmax. The returned tuple is aligned exactly with the order of
+        ``view.available_actions``.
         """
 
         logits = [params.beta * state.q_values[action] for action in view.available_actions]
@@ -170,6 +191,14 @@ class AsocialQLearningKernel:
         -------
         QState
             Updated latent state.
+
+        Notes
+        -----
+        When a reward is present, the chosen action is updated according to
+
+        ``Q[a] <- Q[a] + alpha * (reward - Q[a])``.
+
+        Unchosen actions are left unchanged.
         """
 
         updated_q_values = list(state.q_values)

--- a/src/comp_model/models/kernels/base.py
+++ b/src/comp_model/models/kernels/base.py
@@ -1,4 +1,9 @@
-"""Backend-agnostic kernel metadata and protocols."""
+"""Backend-agnostic kernel metadata and protocols.
+
+The kernel layer defines learning and choice rules only. It is deliberately
+agnostic to task structure, trial schemas, pooling hierarchies, and Stan
+implementation details.
+"""
 
 from __future__ import annotations
 
@@ -23,6 +28,12 @@ class PriorSpec:
         Hyperparameters for the prior family.
     parameterization
         Scale on which the prior is defined.
+
+    Notes
+    -----
+    Priors are declared on the model side so that MLE and Bayesian backends can
+    share one kernel specification even though only the Bayesian backend uses
+    the prior values directly.
     """
 
     family: str
@@ -42,6 +53,11 @@ class InitSpec:
         Strategy-specific keyword arguments.
     default_unconstrained
         Default unconstrained starting value.
+
+    Notes
+    -----
+    Initialization is expressed on the unconstrained scale so that restart
+    generation is aligned with the kernel's transform registry.
     """
 
     strategy: str
@@ -65,6 +81,12 @@ class ParameterSpec:
         Optional prior metadata for Bayesian inference.
     mle_init
         Optional initialization metadata for MLE.
+
+    Notes
+    -----
+    ``transform_id`` links the parameter to the shared transform registry. That
+    single identifier drives constrained parsing in Python and transformed
+    parameter expressions in Stan.
     """
 
     name: str
@@ -92,6 +114,13 @@ class ModelKernelSpec:
         Policy for resetting kernel state, either ``"per_subject"`` or ``"per_block"``.
     description
         Human-readable model description.
+
+    Notes
+    -----
+    ``ModelKernelSpec`` does not reference event-order details such as
+    ``TrialSchema`` or ``node_id``. It describes the kernel's parameters and
+    replay requirements after extraction has already produced flat decision
+    views.
     """
 
     model_id: str
@@ -107,7 +136,15 @@ ParamsT = TypeVar("ParamsT")
 
 
 class ModelKernel(Protocol, Generic[StateT, ParamsT]):
-    """Protocol shared by all backend-agnostic model kernels."""
+    """Protocol shared by all backend-agnostic model kernels.
+
+    Notes
+    -----
+    Kernels only consume :class:`~comp_model.data.extractors.DecisionTrialView`
+    objects. They never inspect raw :class:`~comp_model.data.schema.Event`,
+    :class:`~comp_model.data.schema.Trial`, or
+    :class:`~comp_model.tasks.schemas.TrialSchema` objects.
+    """
 
     @classmethod
     def spec(cls) -> ModelKernelSpec:
@@ -132,7 +169,8 @@ class ModelKernel(Protocol, Generic[StateT, ParamsT]):
         Returns
         -------
         ParamsT
-            Parsed parameter object for the kernel.
+            Parsed parameter object for the kernel, typically after applying the
+            parameter transform specified in :class:`ParameterSpec`.
         """
 
         ...
@@ -150,7 +188,8 @@ class ModelKernel(Protocol, Generic[StateT, ParamsT]):
         Returns
         -------
         StateT
-            Initial latent state.
+            Initial latent state used at subject start or, when configured, at
+            each block boundary.
         """
 
         ...
@@ -175,7 +214,8 @@ class ModelKernel(Protocol, Generic[StateT, ParamsT]):
         Returns
         -------
         tuple[float, ...]
-            Probabilities aligned with ``view.available_actions``.
+            Probabilities aligned with ``view.available_actions`` only. Illegal
+            actions must not appear in the returned tuple.
         """
 
         ...
@@ -200,7 +240,8 @@ class ModelKernel(Protocol, Generic[StateT, ParamsT]):
         Returns
         -------
         StateT
-            Updated latent state.
+            Updated latent state after incorporating any outcome or social
+            information present in ``view``.
         """
 
         ...

--- a/src/comp_model/models/kernels/probabilities.py
+++ b/src/comp_model/models/kernels/probabilities.py
@@ -27,6 +27,13 @@ def stable_softmax(logits: Sequence[float]) -> tuple[float, ...]:
     ------
     ValueError
         Raised when ``logits`` is empty.
+
+    Notes
+    -----
+    The implementation subtracts the maximum logit before exponentiation, then
+    clips the resulting probabilities away from exactly zero before
+    renormalizing. That keeps replay likelihoods finite when downstream code
+    takes logarithms of action probabilities.
     """
 
     logits_array = np.asarray(tuple(logits), dtype=float)

--- a/src/comp_model/models/kernels/social_observed_outcome_q.py
+++ b/src/comp_model/models/kernels/social_observed_outcome_q.py
@@ -1,4 +1,8 @@
-"""Social Q-learning kernel with observed demonstrator outcomes."""
+"""Social Q-learning kernel with observed demonstrator outcomes.
+
+This kernel extends the asocial Q-learning rule with a second learning rate for
+observed demonstrator outcomes.
+"""
 
 from __future__ import annotations
 
@@ -46,7 +50,14 @@ class SocialQState:
 
 
 class SocialObservedOutcomeQKernel:
-    """Q-learning kernel that updates from self and demonstrator outcomes."""
+    """Q-learning kernel that updates from self and demonstrator outcomes.
+
+    Notes
+    -----
+    The kernel still consumes only flat decision views. Whether demonstrator
+    information appeared before the subject's choice or after the outcome is a
+    schema concern handled by extraction.
+    """
 
     @classmethod
     def spec(cls) -> ModelKernelSpec:
@@ -55,7 +66,8 @@ class SocialObservedOutcomeQKernel:
         Returns
         -------
         ModelKernelSpec
-            Static kernel specification.
+            Static kernel specification declaring separate self and social
+            learning rates plus a shared inverse temperature.
         """
 
         return ModelKernelSpec(
@@ -92,7 +104,7 @@ class SocialObservedOutcomeQKernel:
         Returns
         -------
         SocialQParams
-            Typed parameter object.
+            Typed parameter object after applying the shared transform registry.
         """
 
         return SocialQParams(
@@ -141,6 +153,12 @@ class SocialObservedOutcomeQKernel:
         -------
         tuple[float, ...]
             Probabilities aligned with ``view.available_actions``.
+
+        Notes
+        -----
+        Choice probabilities depend only on the agent's current latent Q-values
+        and the legal actions in ``view``. Social information influences choice
+        indirectly through past updates.
         """
 
         logits = [params.beta * state.q_values[action] for action in view.available_actions]
@@ -167,6 +185,12 @@ class SocialObservedOutcomeQKernel:
         -------
         SocialQState
             Updated latent state.
+
+        Notes
+        -----
+        The subject's chosen action is updated with ``alpha_self`` when a reward
+        is present. If demonstrator action and reward are both present, the
+        observed action is updated separately with ``alpha_other``.
         """
 
         updated_q_values = list(state.q_values)

--- a/src/comp_model/models/kernels/transforms.py
+++ b/src/comp_model/models/kernels/transforms.py
@@ -1,4 +1,9 @@
-"""Parameter transform registry shared across inference backends."""
+"""Parameter transform registry shared across inference backends.
+
+Every free parameter is optimized on an unconstrained scale and mapped into its
+support through this registry. The same transform metadata is reused by Python
+MLE code and Stan code generation.
+"""
 
 from __future__ import annotations
 
@@ -30,6 +35,11 @@ def _sigmoid(value: float) -> float:
     -------
     float
         Sigmoid-transformed scalar in `(0, 1)`.
+
+    Notes
+    -----
+    SciPy's numerically stable logistic implementation is used so the forward
+    transform matches the inverse and Stan's ``inv_logit`` behavior closely.
     """
 
     return float(special.expit(value))
@@ -47,6 +57,11 @@ def _inverse_sigmoid(value: float) -> float:
     -------
     float
         Logit-transformed scalar.
+
+    Notes
+    -----
+    Inputs are clamped away from exactly ``0`` and ``1`` so restart generation
+    and inverse-round-trip tests stay finite at closed-domain boundaries.
     """
 
     clamped_value = min(max(value, _PROBABILITY_LOWER_BOUND), _PROBABILITY_UPPER_BOUND)
@@ -65,6 +80,11 @@ def _softplus(value: float) -> float:
     -------
     float
         Positive softplus-transformed scalar.
+
+    Notes
+    -----
+    Large positive values bypass ``exp`` and return the input directly, matching
+    the asymptotic behavior of softplus while avoiding overflow.
     """
 
     if value > 20.0:
@@ -84,6 +104,11 @@ def _inverse_softplus(value: float) -> float:
     -------
     float
         Inverse softplus-transformed scalar.
+
+    Notes
+    -----
+    Inputs are clamped above zero and evaluated with two stable branches so
+    extremely small or moderately large positive values both remain finite.
     """
 
     clamped_value = max(value, _POSITIVE_LOWER_BOUND)
@@ -104,6 +129,11 @@ class Transform:
         Function mapping a constrained scalar to the unconstrained space.
     stan_expression
         Stan template string using `{x}` as the placeholder variable.
+
+    Notes
+    -----
+    ``stan_expression`` keeps the Stan backend tied to the same conceptual
+    transform as the Python backend without having Stan call back into Python.
     """
 
     forward: Callable[[float], float]
@@ -152,6 +182,11 @@ def get_transform(transform_id: str) -> Transform:
     ------
     ValueError
         Raised when the requested transform is not registered.
+
+    Notes
+    -----
+    All backends should resolve transforms through this function instead of
+    assuming hard-coded transform logic at individual call sites.
     """
 
     if transform_id not in TRANSFORM_REGISTRY:

--- a/src/comp_model/runtime/engine.py
+++ b/src/comp_model/runtime/engine.py
@@ -1,4 +1,9 @@
-"""Simulation engine for generating event-based subject data."""
+"""Simulation engine for generating event-based subject data.
+
+The runtime executes task structure and environment dynamics while delegating
+choice and learning to a model kernel. The resulting event traces are the same
+objects later consumed by validation, replay, and Stan export.
+"""
 
 from __future__ import annotations
 
@@ -30,6 +35,11 @@ class SimulationConfig:
     ----------
     seed
         Optional random seed for the subject-level RNG.
+
+    Notes
+    -----
+    Dataset simulation offsets this base seed by subject index so each simulated
+    subject receives an independent but reproducible random stream.
     """
 
     seed: int | None = None
@@ -65,6 +75,24 @@ def simulate_subject(
     -------
     SubjectData
         Simulated hierarchical event trace for one subject.
+
+    Notes
+    -----
+    The simulation loop follows the implementation plan directly:
+
+    1. infer the action count from task metadata,
+    2. initialize kernel state once at subject start,
+    3. reset the environment at each block,
+    4. optionally reset kernel state at block boundaries according to
+       ``kernel.spec().state_reset_policy``,
+    5. step through the schema position by position, sampling subject actions
+       from ``kernel.action_probabilities`` whenever a schema step requires an
+       action, and
+    6. after the full trial event sequence is assembled, extract decision views
+       and apply ``kernel.next_state`` for replay-consistent learning.
+
+    The same extraction path is therefore used for simulation updates and later
+    likelihood evaluation.
     """
 
     rng = np.random.default_rng(config.seed)
@@ -165,6 +193,12 @@ def simulate_dataset(
     -------
     Dataset
         Simulated dataset across all requested subjects.
+
+    Notes
+    -----
+    Subjects are simulated independently with fresh environments returned by
+    ``env_factory``. Subject order follows the insertion order of
+    ``params_per_subject``.
     """
 
     subjects: list[SubjectData] = []
@@ -202,6 +236,12 @@ def _find_subject_input(events: list[Event], node_id: str, actor_id: str) -> Eve
     -------
     Event | None
         Matching subject INPUT event, if any.
+
+    Notes
+    -----
+    This helper searches only the events accumulated for the current in-progress
+    trial, which matches the runtime contract that an action-required decision
+    must have already been preceded by its subject INPUT event.
     """
 
     for event in events:
@@ -231,6 +271,12 @@ def _infer_n_actions_from_task(task: TaskSpec) -> int:
     ------
     ValueError
         Raised when action counts are missing or inconsistent.
+
+    Notes
+    -----
+    The runtime currently relies on ``BlockSpec.metadata['n_actions']`` rather
+    than inferring action count from a model or environment. All blocks must
+    agree on the same action count.
     """
 
     n_actions_values: set[int] = set()

--- a/src/comp_model/tasks/schemas.py
+++ b/src/comp_model/tasks/schemas.py
@@ -1,4 +1,9 @@
-"""Declarative event-order schemas for trial structure."""
+"""Declarative event-order schemas for trial structure.
+
+Trial schemas are the positional source of truth for trial semantics. The same
+schema definition is shared by environments, validators, and extractors so that
+simulation and replay operate on the same event-order contract.
+"""
 
 from __future__ import annotations
 
@@ -22,6 +27,12 @@ class TrialSchemaStep:
         Actor expected at this step.
     action_required
         Whether the simulation engine must supply an action here.
+
+    Notes
+    -----
+    ``node_id`` and ``actor_id`` are matching constraints, not semantic dispatch
+    keys. Extraction logic stays schema-driven and positional instead of
+    branching on arbitrary node-name strings.
     """
 
     phase: EventPhase
@@ -40,6 +51,14 @@ class TrialSchema:
         Stable identifier for the schema.
     steps
         Ordered schema steps that each trial must match positionally.
+
+    Notes
+    -----
+    ``TrialSchema`` does three jobs with the same positional contract:
+
+    1. it tells environments what event type should occur next,
+    2. it validates recorded trials, and
+    3. it tells the extractor how to interpret events around each decision.
     """
 
     schema_id: str
@@ -57,6 +76,12 @@ class TrialSchema:
         -------
         None
             This function raises on any mismatch.
+
+        Raises
+        ------
+        ValueError
+            Raised when event count, phase, ``node_id``, ``actor_id``, event
+            index, or required payload keys differ from the schema contract.
         """
 
         if len(trial.events) != len(self.steps):
@@ -95,7 +120,7 @@ class TrialSchema:
         Returns
         -------
         tuple[int, ...]
-            Positions of decision steps.
+            Positions whose phase is :class:`~comp_model.data.schema.EventPhase.DECISION`.
         """
 
         return tuple(
@@ -109,7 +134,7 @@ class TrialSchema:
         Returns
         -------
         tuple[int, ...]
-            Positions whose `action_required` flag is true.
+            Positions whose ``action_required`` flag is true.
         """
 
         return tuple(index for index, step in enumerate(self.steps) if step.action_required)

--- a/src/comp_model/tasks/spec.py
+++ b/src/comp_model/tasks/spec.py
@@ -1,4 +1,9 @@
-"""Task-level design specifications."""
+"""Task-level design specifications.
+
+Task objects describe experimental structure independently of any agent or
+inference backend. They own block order, condition labels, trial counts,
+schemas, and task metadata consumed by environments.
+"""
 
 from __future__ import annotations
 
@@ -27,6 +32,12 @@ class BlockSpec:
         Trial schema executed by the environment.
     metadata
         Optional block-level task metadata.
+
+    Notes
+    -----
+    Environments read ``metadata`` to configure block-specific dynamics such as
+    action count or reward contingencies. Kernels do not read ``BlockSpec``
+    directly.
     """
 
     condition: str
@@ -45,6 +56,12 @@ class TaskSpec:
         Stable task identifier.
     blocks
         Ordered block specifications for the task.
+
+    Notes
+    -----
+    ``TaskSpec`` is the structural design layer. The runtime executes it, while
+    fitted models only ever see extracted decision views derived from the event
+    traces it generates.
     """
 
     task_id: str
@@ -57,7 +74,7 @@ class TaskSpec:
         Returns
         -------
         int
-            Number of block specifications.
+            Number of block specifications in execution order.
         """
 
         return len(self.blocks)
@@ -69,7 +86,8 @@ class TaskSpec:
         Returns
         -------
         tuple[str, ...]
-            Ordered unique condition labels.
+            Ordered unique condition labels, preserving the first occurrence of
+            each condition in ``blocks``.
         """
 
         seen: set[str] = set()


### PR DESCRIPTION
## Summary
- add the missing NumPy-style docstrings on the nested MLE optimizer objective closures
- verify recursive docstring coverage across src/

## Verification
- recursive AST docstring scan over src/
- make check