### PR TITLE
refactor: move PriorSpec from kernel to inference layer

### DIFF
--- a/example/asocial_qlearning/mle.py
+++ b/example/asocial_qlearning/mle.py
@@ -45,9 +45,7 @@ params_per_subject = {f"sub_{i:02d}": true_params for i in range(N_SUBJECTS)}
 
 dataset = simulate_dataset(
     task=task,
-    env_factory=lambda: StationaryBanditEnvironment(
-        n_actions=N_ACTIONS, reward_probs=REWARD_PROBS
-    ),
+    env_factory=lambda: StationaryBanditEnvironment(n_actions=N_ACTIONS, reward_probs=REWARD_PROBS),
     kernel=kernel,
     params_per_subject=params_per_subject,
     config=SimulationConfig(seed=42),

--- a/example/asocial_qlearning/mle_within_subject.py
+++ b/example/asocial_qlearning/mle_within_subject.py
@@ -82,9 +82,7 @@ for i in range(N_SUBJECTS):
     blocks = []
     for block_idx, block_spec in enumerate(task.blocks):
         condition = block_spec.condition
-        env = StationaryBanditEnvironment(
-            n_actions=N_ACTIONS, reward_probs=REWARD_PROBS[condition]
-        )
+        env = StationaryBanditEnvironment(n_actions=N_ACTIONS, reward_probs=REWARD_PROBS[condition])
         params = TRUE_PARAMS[condition]
         sub = simulate_subject(
             task=TaskSpec(
@@ -126,11 +124,7 @@ mle_config = InferenceConfig(
 sigmoid = get_transform("sigmoid")
 softplus = get_transform("softplus")
 
-print(
-    f"\n{'Subject':<10} {'Cond':<8} "
-    f"{'True a':>8} {'Fit a':>8} "
-    f"{'True b':>8} {'Fit b':>8}"
-)
+print(f"\n{'Subject':<10} {'Cond':<8} {'True a':>8} {'Fit a':>8} {'True b':>8} {'Fit b':>8}")
 print("-" * 56)
 
 for subject in dataset.subjects:
@@ -145,9 +139,6 @@ for subject in dataset.subjects:
             f"{true_p.alpha:>8.3f} {fit_alpha:>8.3f} "
             f"{true_p.beta:>8.3f} {fit_beta:>8.3f}"
         )
-    print(
-        f"  -> LL={result.log_likelihood:.2f}, "
-        f"AIC={result.aic:.2f}, BIC={result.bic:.2f}"
-    )
+    print(f"  -> LL={result.log_likelihood:.2f}, AIC={result.aic:.2f}, BIC={result.bic:.2f}")
 
 print("\nDone.")

--- a/example/asocial_qlearning/stan.py
+++ b/example/asocial_qlearning/stan.py
@@ -31,6 +31,7 @@ def softplus_vec(x: np.ndarray) -> np.ndarray:
 def inv_softplus_vec(x: np.ndarray) -> np.ndarray:
     return np.log(np.expm1(x))
 
+
 # ── 1. Define task ──────────────────────────────────────────────────────────
 N_ACTIONS = 2
 N_TRIALS = 200
@@ -55,9 +56,9 @@ REWARD_PROBS = (0.8, 0.2)
 kernel = AsocialQLearningKernel()
 
 # Population-level ground truth (unconstrained scale)
-TRUE_MU_ALPHA_Z = float(inv_sigmoid_vec(0.3))   # ≈ -0.847
+TRUE_MU_ALPHA_Z = float(inv_sigmoid_vec(0.3))  # ≈ -0.847
 TRUE_SD_ALPHA_Z = 0.5
-TRUE_MU_BETA_Z = float(inv_softplus_vec(np.array(2.0)))   # ≈ 1.687
+TRUE_MU_BETA_Z = float(inv_softplus_vec(np.array(2.0)))  # ≈ 1.687
 TRUE_SD_BETA_Z = 0.5
 
 rng = np.random.default_rng(123)
@@ -75,14 +76,14 @@ params_per_subject = {
 print("Ground-truth per-subject parameters:")
 for sid, p in params_per_subject.items():
     print(f"  {sid}: alpha={p.alpha:.3f}, beta={p.beta:.3f}")
-print(f"Population: mu_alpha={float(sigmoid_vec(TRUE_MU_ALPHA_Z)):.3f}, "
-      f"mu_beta={float(softplus_vec(np.array(TRUE_MU_BETA_Z))):.3f}")
+print(
+    f"Population: mu_alpha={float(sigmoid_vec(TRUE_MU_ALPHA_Z)):.3f}, "
+    f"mu_beta={float(softplus_vec(np.array(TRUE_MU_BETA_Z))):.3f}"
+)
 
 dataset = simulate_dataset(
     task=task,
-    env_factory=lambda: StationaryBanditEnvironment(
-        n_actions=N_ACTIONS, reward_probs=REWARD_PROBS
-    ),
+    env_factory=lambda: StationaryBanditEnvironment(n_actions=N_ACTIONS, reward_probs=REWARD_PROBS),
     kernel=kernel,
     params_per_subject=params_per_subject,
     config=SimulationConfig(seed=42),

--- a/example/asocial_qlearning/stan_no_pooling.py
+++ b/example/asocial_qlearning/stan_no_pooling.py
@@ -53,9 +53,7 @@ params_per_subject = {f"sub_{i:02d}": true_params for i in range(N_SUBJECTS)}
 
 dataset = simulate_dataset(
     task=task,
-    env_factory=lambda: StationaryBanditEnvironment(
-        n_actions=N_ACTIONS, reward_probs=REWARD_PROBS
-    ),
+    env_factory=lambda: StationaryBanditEnvironment(n_actions=N_ACTIONS, reward_probs=REWARD_PROBS),
     kernel=kernel,
     params_per_subject=params_per_subject,
     config=SimulationConfig(seed=42),

--- a/example/asocial_qlearning/stan_within_subject.py
+++ b/example/asocial_qlearning/stan_within_subject.py
@@ -81,9 +81,7 @@ for i in range(N_SUBJECTS):
     blocks = []
     for block_idx, block_spec in enumerate(task.blocks):
         condition = block_spec.condition
-        env = StationaryBanditEnvironment(
-            n_actions=N_ACTIONS, reward_probs=REWARD_PROBS[condition]
-        )
+        env = StationaryBanditEnvironment(n_actions=N_ACTIONS, reward_probs=REWARD_PROBS[condition])
         sub = simulate_subject(
             task=TaskSpec(task_id="tmp", blocks=(block_spec,)),
             env=env,
@@ -119,14 +117,17 @@ adapter = AsocialQLearningStanAdapter()
 sigmoid = get_transform("sigmoid")
 softplus = get_transform("softplus")
 
-print(f"\n{'Subject':<10} {'Cond':<8} {'True a':>8} {'Post. a':>10} "
-      f"{'True b':>8} {'Post. b':>10}")
+print(f"\n{'Subject':<10} {'Cond':<8} {'True a':>8} {'Post. a':>10} {'True b':>8} {'Post. b':>10}")
 print("-" * 60)
 
 for subject in dataset.subjects:
     result = fit(
-        stan_config, kernel, subject, ASOCIAL_BANDIT_SCHEMA,
-        layout=layout, adapter=adapter,
+        stan_config,
+        kernel,
+        subject,
+        ASOCIAL_BANDIT_SCHEMA,
+        layout=layout,
+        adapter=adapter,
     )
 
     # alpha, beta are vectors of size C in posterior samples

--- a/example/social_observed_outcome_q/mle_recovery.py
+++ b/example/social_observed_outcome_q/mle_recovery.py
@@ -55,9 +55,7 @@ def main() -> None:
         ),
         task=task,
         env_factory=lambda: SocialBanditEnvironment(
-            inner=StationaryBanditEnvironment(
-                n_actions=N_ACTIONS, reward_probs=(0.8, 0.2)
-            ),
+            inner=StationaryBanditEnvironment(n_actions=N_ACTIONS, reward_probs=(0.8, 0.2)),
             demonstrator_policy=(0.5, 0.5),
         ),
         kernel=kernel,

--- a/example/social_observed_outcome_q/stan.py
+++ b/example/social_observed_outcome_q/stan.py
@@ -32,6 +32,7 @@ def softplus_vec(x: np.ndarray) -> np.ndarray:
 def inv_softplus_vec(x: np.ndarray) -> np.ndarray:
     return np.log(np.expm1(x))
 
+
 # ── 1. Define task ──────────────────────────────────────────────────────────
 N_ACTIONS = 2
 N_TRIALS = 200
@@ -80,13 +81,17 @@ params_per_subject = {
 
 print("Ground-truth per-subject parameters:")
 for sid, p in params_per_subject.items():
-    print(f"  {sid}: alpha_self={p.alpha_self:.3f}, "
-          f"alpha_other={p.alpha_other:.3f}, beta={p.beta:.3f}")
+    print(
+        f"  {sid}: alpha_self={p.alpha_self:.3f}, "
+        f"alpha_other={p.alpha_other:.3f}, beta={p.beta:.3f}"
+    )
 true_mu_as = float(sigmoid_vec(TRUE_MU_ALPHA_SELF_Z))
 true_mu_ao = float(sigmoid_vec(TRUE_MU_ALPHA_OTHER_Z))
 true_mu_b = float(softplus_vec(np.array(TRUE_MU_BETA_Z)))
-print(f"Population: mu_alpha_self={true_mu_as:.3f}, "
-      f"mu_alpha_other={true_mu_ao:.3f}, mu_beta={true_mu_b:.3f}")
+print(
+    f"Population: mu_alpha_self={true_mu_as:.3f}, "
+    f"mu_alpha_other={true_mu_ao:.3f}, mu_beta={true_mu_b:.3f}"
+)
 
 dataset = simulate_dataset(
     task=task,

--- a/example/social_observed_outcome_q/stan_per_subject_recovery.py
+++ b/example/social_observed_outcome_q/stan_per_subject_recovery.py
@@ -52,9 +52,7 @@ def main() -> None:
         ),
         task=task,
         env_factory=lambda: SocialBanditEnvironment(
-            inner=StationaryBanditEnvironment(
-                n_actions=N_ACTIONS, reward_probs=(0.8, 0.2)
-            ),
+            inner=StationaryBanditEnvironment(n_actions=N_ACTIONS, reward_probs=(0.8, 0.2)),
             demonstrator_policy=(0.5, 0.5),
         ),
         kernel=kernel,

--- a/example/social_observed_outcome_q/stan_post_outcome.py
+++ b/example/social_observed_outcome_q/stan_post_outcome.py
@@ -32,6 +32,7 @@ def softplus_vec(x: np.ndarray) -> np.ndarray:
 def inv_softplus_vec(x: np.ndarray) -> np.ndarray:
     return np.log(np.expm1(x))
 
+
 # ── 1. Define task ──────────────────────────────────────────────────────────
 N_ACTIONS = 2
 N_TRIALS = 200
@@ -80,13 +81,17 @@ params_per_subject = {
 
 print("Ground-truth per-subject parameters:")
 for sid, p in params_per_subject.items():
-    print(f"  {sid}: alpha_self={p.alpha_self:.3f}, "
-          f"alpha_other={p.alpha_other:.3f}, beta={p.beta:.3f}")
+    print(
+        f"  {sid}: alpha_self={p.alpha_self:.3f}, "
+        f"alpha_other={p.alpha_other:.3f}, beta={p.beta:.3f}"
+    )
 true_mu_as = float(sigmoid_vec(TRUE_MU_ALPHA_SELF_Z))
 true_mu_ao = float(sigmoid_vec(TRUE_MU_ALPHA_OTHER_Z))
 true_mu_b = float(softplus_vec(np.array(TRUE_MU_BETA_Z)))
-print(f"Population: mu_alpha_self={true_mu_as:.3f}, "
-      f"mu_alpha_other={true_mu_ao:.3f}, mu_beta={true_mu_b:.3f}")
+print(
+    f"Population: mu_alpha_self={true_mu_as:.3f}, "
+    f"mu_alpha_other={true_mu_ao:.3f}, mu_beta={true_mu_b:.3f}"
+)
 
 dataset = simulate_dataset(
     task=task,

--- a/example/social_observed_outcome_q/stan_recovery.py
+++ b/example/social_observed_outcome_q/stan_recovery.py
@@ -53,9 +53,7 @@ def main() -> None:
         ),
         task=task,
         env_factory=lambda: SocialBanditEnvironment(
-            inner=StationaryBanditEnvironment(
-                n_actions=N_ACTIONS, reward_probs=(0.8, 0.2)
-            ),
+            inner=StationaryBanditEnvironment(n_actions=N_ACTIONS, reward_probs=(0.8, 0.2)),
             demonstrator_policy=(0.5, 0.5),
         ),
         kernel=kernel,

--- a/src/comp_model/inference/__init__.py
+++ b/src/comp_model/inference/__init__.py
@@ -1,6 +1,6 @@
 """Inference backends and configuration."""
 
-from comp_model.inference.config import HierarchyStructure, InferenceConfig
+from comp_model.inference.config import HierarchyStructure, InferenceConfig, PriorSpec
 from comp_model.inference.dispatch import fit
 
-__all__ = ["HierarchyStructure", "InferenceConfig", "fit"]
+__all__ = ["HierarchyStructure", "InferenceConfig", "PriorSpec", "fit"]

--- a/src/comp_model/inference/bayes/stan/adapters/asocial_q_learning.py
+++ b/src/comp_model/inference/bayes/stan/adapters/asocial_q_learning.py
@@ -17,7 +17,7 @@ from comp_model.inference.bayes.stan.data_builder import (
     dataset_to_step_data,
     subject_to_step_data,
 )
-from comp_model.inference.config import HierarchyStructure
+from comp_model.inference.config import HierarchyStructure, PriorSpec
 from comp_model.models.kernels.asocial_q_learning import AsocialQLearningKernel
 
 if TYPE_CHECKING:
@@ -76,6 +76,7 @@ class AsocialQLearningStanAdapter:
         schema: TrialSchema,
         hierarchy: HierarchyStructure,
         layout: SharedDeltaLayout | None = None,
+        prior_specs: dict[str, PriorSpec] | None = None,
     ) -> dict[str, Any]:
         """Build Stan data for the asocial Q-learning programs.
 
@@ -89,6 +90,8 @@ class AsocialQLearningStanAdapter:
             Hierarchy structure targeted by the Stan program.
         layout
             Optional condition-aware parameter layout.
+        prior_specs
+            Optional mapping from parameter name to prior specification.
 
         Returns
         -------
@@ -123,7 +126,7 @@ class AsocialQLearningStanAdapter:
             )
 
         # Add prior, reset, and initial value data
-        add_prior_data(stan_data, kspec)
+        add_prior_data(stan_data, kspec, prior_specs)
         add_state_reset_data(stan_data, kspec)
         add_initial_value_data(stan_data, kspec)
 

--- a/src/comp_model/inference/bayes/stan/adapters/base.py
+++ b/src/comp_model/inference/bayes/stan/adapters/base.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     from comp_model.data.schema import Dataset, SubjectData
-    from comp_model.inference.config import HierarchyStructure
+    from comp_model.inference.config import HierarchyStructure, PriorSpec
     from comp_model.models.condition.shared_delta import SharedDeltaLayout
     from comp_model.models.kernels.base import ModelKernelSpec
     from comp_model.tasks.schemas import TrialSchema
@@ -48,6 +48,7 @@ class StanAdapter(Protocol):
         schema: TrialSchema,
         hierarchy: HierarchyStructure,
         layout: SharedDeltaLayout | None = None,
+        prior_specs: dict[str, PriorSpec] | None = None,
     ) -> dict[str, Any]:
         """Build Stan data for a subject or dataset.
 
@@ -61,6 +62,8 @@ class StanAdapter(Protocol):
             Hierarchy structure targeted by the Stan program.
         layout
             Optional condition-aware parameter layout.
+        prior_specs
+            Optional mapping from parameter name to prior specification.
 
         Returns
         -------

--- a/src/comp_model/inference/bayes/stan/adapters/social_observed_outcome_q.py
+++ b/src/comp_model/inference/bayes/stan/adapters/social_observed_outcome_q.py
@@ -17,7 +17,7 @@ from comp_model.inference.bayes.stan.data_builder import (
     dataset_to_step_data,
     subject_to_step_data,
 )
-from comp_model.inference.config import HierarchyStructure
+from comp_model.inference.config import HierarchyStructure, PriorSpec
 from comp_model.models.kernels.social_observed_outcome_q import (
     SocialObservedOutcomeQKernel,
 )
@@ -74,6 +74,7 @@ class SocialObservedOutcomeQStanAdapter:
         schema: TrialSchema,
         hierarchy: HierarchyStructure,
         layout: SharedDeltaLayout | None = None,
+        prior_specs: dict[str, PriorSpec] | None = None,
     ) -> dict[str, Any]:
         """Build Stan data for the social Q-learning programs.
 
@@ -87,6 +88,8 @@ class SocialObservedOutcomeQStanAdapter:
             Hierarchy structure targeted by the Stan program.
         layout
             Optional condition-aware parameter layout.
+        prior_specs
+            Optional mapping from parameter name to prior specification.
 
         Returns
         -------
@@ -123,7 +126,7 @@ class SocialObservedOutcomeQStanAdapter:
             )
 
         # Add prior, reset, and initial value data
-        add_prior_data(stan_data, kspec)
+        add_prior_data(stan_data, kspec, prior_specs)
         add_state_reset_data(stan_data, kspec)
         add_initial_value_data(stan_data, kspec)
 

--- a/src/comp_model/inference/bayes/stan/backend.py
+++ b/src/comp_model/inference/bayes/stan/backend.py
@@ -19,7 +19,7 @@ from comp_model.inference.bayes.result import BayesFitResult
 if TYPE_CHECKING:
     from comp_model.data.schema import Dataset, SubjectData
     from comp_model.inference.bayes.stan.adapters.base import StanAdapter
-    from comp_model.inference.config import HierarchyStructure
+    from comp_model.inference.config import HierarchyStructure, PriorSpec
     from comp_model.models.condition.shared_delta import SharedDeltaLayout
     from comp_model.tasks.schemas import TrialSchema
 
@@ -67,6 +67,7 @@ def fit_stan(
     hierarchy: HierarchyStructure,
     layout: SharedDeltaLayout | None = None,
     config: StanFitConfig | None = None,
+    prior_specs: dict[str, PriorSpec] | None = None,
 ) -> BayesFitResult:
     """Fit a model with Stan using the supplied adapter and data.
 
@@ -106,7 +107,7 @@ def fit_stan(
         stanc_options={"include-paths": [functions_dir]},
     )
     fit = model.sample(
-        data=adapter.build_stan_data(data, schema, hierarchy, layout),
+        data=adapter.build_stan_data(data, schema, hierarchy, layout, prior_specs),
         iter_warmup=resolved_config.n_warmup,
         iter_sampling=resolved_config.n_samples,
         chains=resolved_config.n_chains,

--- a/src/comp_model/inference/bayes/stan/data_builder.py
+++ b/src/comp_model/inference/bayes/stan/data_builder.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
     from comp_model.data.extractors import DecisionTrialView
     from comp_model.data.schema import Dataset, SubjectData
+    from comp_model.inference.config import PriorSpec
     from comp_model.models.condition.shared_delta import SharedDeltaLayout
     from comp_model.models.kernels.base import ModelKernelSpec
     from comp_model.tasks.schemas import TrialSchema
@@ -259,15 +260,23 @@ def add_initial_value_data(stan_data: dict[str, Any], kernel_spec: ModelKernelSp
     stan_data["q_init"] = float(kernel_spec.initial_value)
 
 
-def add_prior_data(stan_data: dict[str, Any], kernel_spec: ModelKernelSpec) -> None:
-    """Add prior hyperparameters from kernel metadata to a Stan data dictionary.
+def add_prior_data(
+    stan_data: dict[str, Any],
+    kernel_spec: ModelKernelSpec,
+    prior_specs: dict[str, PriorSpec] | None = None,
+) -> None:
+    """Add prior hyperparameters to a Stan data dictionary.
 
     Parameters
     ----------
     stan_data
         Stan data dictionary to mutate.
     kernel_spec
-        Kernel specification whose parameter priors should be exported.
+        Kernel specification whose parameter names drive the export.
+    prior_specs
+        Optional mapping from parameter name to prior specification.
+        Parameters without an entry fall back to ``Normal(0, 2)`` on the
+        unconstrained scale.
 
     Returns
     -------
@@ -281,11 +290,11 @@ def add_prior_data(stan_data: dict[str, Any], kernel_spec: ModelKernelSpec) -> N
     fall back to ``Normal(0, 2)``.
     """
 
+    priors = prior_specs or {}
     for parameter in kernel_spec.parameter_specs:
-        if parameter.prior is not None:
-            family_id, p1, p2, p3 = prior_spec_to_stan_data(
-                parameter.prior.family, parameter.prior.kwargs
-            )
+        prior = priors.get(parameter.name)
+        if prior is not None:
+            family_id, p1, p2, p3 = prior_spec_to_stan_data(prior.family, prior.kwargs)
         else:
             family_id, p1, p2, p3 = 1, 0.0, 2.0, 0.0  # Normal(0, 2) default
         stan_data[f"{parameter.name}_prior_family"] = family_id

--- a/src/comp_model/inference/config.py
+++ b/src/comp_model/inference/config.py
@@ -9,7 +9,28 @@ from typing import TYPE_CHECKING
 from comp_model.inference.mle.optimize import MleOptimizerConfig
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from comp_model.inference.bayes.stan import StanFitConfig
+
+
+@dataclass(frozen=True, slots=True)
+class PriorSpec:
+    """Prior metadata for a model parameter.
+
+    Attributes
+    ----------
+    family
+        Prior family identifier, such as ``"normal"``.
+    kwargs
+        Hyperparameters for the prior family.
+    parameterization
+        Scale on which the prior is defined.
+    """
+
+    family: str
+    kwargs: Mapping[str, float]
+    parameterization: str = "unconstrained"
 
 
 class HierarchyStructure(StrEnum):
@@ -43,6 +64,10 @@ class InferenceConfig:
         Configuration for MLE optimization.
     stan_config
         Optional backend-specific Stan configuration.
+    prior_specs
+        Optional mapping from parameter name to prior specification.
+        Only used by the Bayesian backend. Parameters without an entry
+        fall back to ``Normal(0, 2)`` on the unconstrained scale.
 
     Notes
     -----
@@ -56,3 +81,4 @@ class InferenceConfig:
     sampler: str = "nuts"
     mle_config: MleOptimizerConfig = field(default_factory=MleOptimizerConfig)
     stan_config: StanFitConfig | None = None
+    prior_specs: dict[str, PriorSpec] | None = None

--- a/src/comp_model/inference/dispatch.py
+++ b/src/comp_model/inference/dispatch.py
@@ -77,6 +77,8 @@ def fit(
         )
         fit_stan = stan_backend.fit_stan
 
-        return fit_stan(adapter, data, schema, config.hierarchy, layout, config.stan_config)
+        return fit_stan(
+            adapter, data, schema, config.hierarchy, layout, config.stan_config, config.prior_specs
+        )
 
     raise ValueError(f"Unknown backend: {config.backend!r}")

--- a/src/comp_model/models/kernels/__init__.py
+++ b/src/comp_model/models/kernels/__init__.py
@@ -6,7 +6,6 @@ from comp_model.models.kernels.base import (
     ModelKernel,
     ModelKernelSpec,
     ParameterSpec,
-    PriorSpec,
 )
 from comp_model.models.kernels.social_observed_outcome_q import (
     SocialObservedOutcomeQKernel,
@@ -22,7 +21,6 @@ __all__ = [
     "ModelKernel",
     "ModelKernelSpec",
     "ParameterSpec",
-    "PriorSpec",
     "QParams",
     "QState",
     "SocialObservedOutcomeQKernel",

--- a/src/comp_model/models/kernels/asocial_q_learning.py
+++ b/src/comp_model/models/kernels/asocial_q_learning.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from comp_model.models.kernels.base import InitSpec, ModelKernelSpec, ParameterSpec, PriorSpec
+from comp_model.models.kernels.base import InitSpec, ModelKernelSpec, ParameterSpec
 from comp_model.models.kernels.probabilities import stable_softmax
 from comp_model.models.kernels.transforms import get_transform
 
@@ -76,7 +76,6 @@ class AsocialQLearningKernel:
                     name="alpha",
                     transform_id="sigmoid",
                     description="learning rate",
-                    prior=PriorSpec(family="normal", kwargs={"mu": 0.0, "sigma": 1.5}),
                     mle_init=InitSpec(
                         strategy="fixed",
                         kwargs={},
@@ -87,7 +86,6 @@ class AsocialQLearningKernel:
                     name="beta",
                     transform_id="softplus",
                     description="inverse temperature",
-                    prior=PriorSpec(family="normal", kwargs={"mu": 0.0, "sigma": 2.0}),
                     mle_init=InitSpec(
                         strategy="fixed",
                         kwargs={},

--- a/src/comp_model/models/kernels/base.py
+++ b/src/comp_model/models/kernels/base.py
@@ -17,31 +17,6 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True, slots=True)
-class PriorSpec:
-    """Prior metadata for a model parameter.
-
-    Attributes
-    ----------
-    family
-        Prior family identifier, such as ``"normal"``.
-    kwargs
-        Hyperparameters for the prior family.
-    parameterization
-        Scale on which the prior is defined.
-
-    Notes
-    -----
-    Priors are declared on the model side so that MLE and Bayesian backends can
-    share one kernel specification even though only the Bayesian backend uses
-    the prior values directly.
-    """
-
-    family: str
-    kwargs: Mapping[str, float]
-    parameterization: str = "unconstrained"
-
-
-@dataclass(frozen=True, slots=True)
 class InitSpec:
     """Initialization metadata for MLE optimization.
 
@@ -77,8 +52,6 @@ class ParameterSpec:
         Identifier in the transform registry.
     description
         Human-readable description of the parameter.
-    prior
-        Optional prior metadata for Bayesian inference.
     mle_init
         Optional initialization metadata for MLE.
 
@@ -92,7 +65,6 @@ class ParameterSpec:
     name: str
     transform_id: str
     description: str = ""
-    prior: PriorSpec | None = None
     mle_init: InitSpec | None = None
 
 

--- a/tests/test_models/test_kernel_base.py
+++ b/tests/test_models/test_kernel_base.py
@@ -1,10 +1,10 @@
 """Tests for kernel metadata structures."""
 
-from comp_model.models.kernels.base import InitSpec, ModelKernelSpec, ParameterSpec, PriorSpec
+from comp_model.models.kernels.base import InitSpec, ModelKernelSpec, ParameterSpec
 
 
-def test_parameter_spec_captures_prior_and_init_metadata() -> None:
-    """Ensure parameter metadata stores prior and init specifications.
+def test_parameter_spec_captures_init_metadata() -> None:
+    """Ensure parameter metadata stores init specification.
 
     Returns
     -------
@@ -12,17 +12,14 @@ def test_parameter_spec_captures_prior_and_init_metadata() -> None:
         This test asserts stored dataclass values.
     """
 
-    prior = PriorSpec(family="normal", kwargs={"mu": 0.0, "sigma": 1.0})
     init = InitSpec(strategy="fixed", kwargs={}, default_unconstrained=0.5)
     parameter = ParameterSpec(
         name="alpha",
         transform_id="sigmoid",
         description="learning rate",
-        prior=prior,
         mle_init=init,
     )
 
-    assert parameter.prior == prior
     assert parameter.mle_init == init
 
 


### PR DESCRIPTION
## Summary
- Move `PriorSpec` from `models/kernels/base.py` to `inference/config.py` — priors are an inference concern, not a model kernel concern
- Add `prior_specs: dict[str, PriorSpec] | None` field to `InferenceConfig` so priors can be configured per-fit without modifying kernel definitions
- Thread `prior_specs` through the call chain: `dispatch.fit()` → `fit_stan()` → `adapter.build_stan_data()` → `add_prior_data()`
- Parameters without an explicit prior default to `Normal(0, 2)` on the unconstrained scale

## Test plan
- [x] All 88 existing tests pass
- [x] ruff lint + format clean
- [x] pyright clean
- [ ] Verify Stan fitting works with custom `prior_specs` on `InferenceConfig`

🤖 Generated with [Claude Code](https://claude.com/claude-code)