### PR TITLE
docs: rewrite docstrings and comments for non-developer readability

### DIFF
--- a/src/comp_model/data/extractors.py
+++ b/src/comp_model/data/extractors.py
@@ -1,8 +1,26 @@
-"""Schema-driven extraction from event traces to model-facing decision views.
+"""Translating raw event logs into flat summaries that learning models can use.
 
-This module bridges the canonical event hierarchy and backend-agnostic model
-kernels. Extraction is positional and schema-specific, while the resulting
-decision views are flat and order-agnostic.
+Raw experimental data is stored as a sequence of events (see schema.py).
+Learning models, however, need a much simpler picture: for each decision
+moment, just tell me what options were available, what was chosen, and what
+reward was received.
+
+This module does that translation. Its main job is to walk through a trial's
+events and produce ``DecisionTrialView`` objects — clean, flat summaries of
+each decision moment. Models never see raw events; they only ever see these
+summaries.
+
+The main function is ``replay_trial_steps``, which replays a trial step by
+step and emits two kinds of signals to the caller:
+
+- A **DECISION** signal: "the participant just made a choice — evaluate how
+  probable that choice was under the current model."
+- An **UPDATE** signal: "a learning step should happen now — advance the
+  model's internal state using this choice and reward."
+
+This separation keeps the model fitting code clean: the caller just needs to
+respond to these two signals without worrying about which event in the raw
+log triggered them.
 """
 
 from __future__ import annotations
@@ -21,35 +39,39 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, slots=True)
 class DecisionTrialView:
-    """Flat per-decision record consumed by model kernels.
+    """A clean summary of one decision moment, ready for the learning model to use.
+
+    Rather than handing the model a sequence of raw events, we package
+    everything it needs for one decision into this flat record. This means
+    the same model code works regardless of how the task's event sequence is
+    structured — the extractor takes care of the bookkeeping.
 
     Attributes
     ----------
     trial_index
-        Index of the source trial within its block.
+        Which trial within the current block this decision came from.
     available_actions
-        Legal actions at the decision point.
+        The options that were available at this decision point (e.g.
+        ``(0, 1, 2)`` for a three-armed bandit).
     choice
-        Chosen action value, or ``None`` when the view is produced before the
-        subject's decision (e.g. a social-only update step).
+        The action that was chosen (e.g. ``1``). This is ``None`` when the
+        view represents a social-observation update — i.e. the participant is
+        learning from watching a demonstrator, not from their own choice.
     reward
-        Observed reward, if present.
+        The reward the participant received, if this was their own decision.
+        ``None`` for social-observation update steps.
     observation
-        Subject-facing observation payload.
+        Any additional information the participant saw alongside the options
+        (e.g. stimulus features).
     social_action
-        Observed demonstrator action, if present.
+        The action the demonstrator chose, if one was observed on this step.
+        ``None`` if no demonstrator was present or their action was not visible.
     social_reward
-        Observed demonstrator reward, if present (only when ``"reward"`` is in
-        the corresponding UPDATE step's ``observable_fields``).
+        The reward the demonstrator received, if it was visible to the
+        participant. This is only populated when the task schema explicitly
+        marks the demonstrator's reward as observable. ``None`` otherwise.
     metadata
-        Additional extractor metadata.
-
-    Notes
-    -----
-    Kernels consume :class:`DecisionTrialView` rather than :class:`Event`,
-    :class:`Trial`, or :class:`TrialSchema`. This allows the same kernel to work
-    with different event orders as long as the extractor produces the same flat
-    fields.
+        Any additional bookkeeping information attached by the extractor.
     """
 
     trial_index: int
@@ -66,36 +88,56 @@ def replay_trial_steps(
     trial: Trial,
     schema: TrialSchema,
 ) -> Iterator[tuple[EventPhase, str, DecisionTrialView]]:
-    """Yield schema-ordered replay steps for engine and MLE use.
+    """Walk through a trial event-by-event and emit signals the model should respond to.
 
-    Steps through the schema positionally, emitting one item per DECISION
-    (subject only) or UPDATE step.  UPDATE event payloads carry the actor's
-    choice and reward directly, so no accumulation of choices or rewards is
-    needed beyond tracking INPUT events for ``available_actions``.
+    This function is the bridge between raw data and model fitting. It reads a
+    trial's events in order and, at the right moments, yields a signal telling
+    the caller what the model should do next. There are two kinds of signals:
+
+    - **DECISION** (``EventPhase.DECISION``): the participant just made a
+      choice. The caller should ask the model "how probable was this action?"
+      and record that probability (e.g. for computing log-likelihood).
+      Only emitted for the participant's own choices, not a demonstrator's.
+
+    - **UPDATE** (``EventPhase.UPDATE``): a learning step should happen now.
+      The caller should advance the model's internal state (e.g. update
+      action values) using the choice and reward provided in the view. The
+      UPDATE payload already contains both the choice that was made and the
+      reward that resulted, so there is no need to remember information from
+      earlier events.
+
+    Design note — why carry choice and reward in the UPDATE payload?
+    In principle you could reconstruct them by looking back at earlier events.
+    Instead, the schema pre-packages them in the UPDATE event so this function
+    can emit a complete view without accumulating state across events.
+    The only thing that does need to be tracked across events is the most
+    recent INPUT event per actor, because that is where ``available_actions``
+    lives — and we store that in ``actor_inputs`` below.
 
     Parameters
     ----------
     trial
-        Trial whose events should be replayed.
+        The trial to replay.
     schema
-        Schema defining the positional meaning of each event.
+        Defines the expected structure of this trial — which events appear in
+        which positions and what each one means.
 
     Yields
     ------
     event_phase : EventPhase
-        ``EventPhase.DECISION`` — caller should evaluate
-        ``action_probabilities`` and accumulate log-probability. Only emitted
-        for subject DECISION steps.
-        ``EventPhase.UPDATE`` — caller should call ``next_state``.
+        ``EventPhase.DECISION`` — the model should evaluate action
+        probabilities for this choice.
+        ``EventPhase.UPDATE`` — the model should update its internal state.
     learner_id : str
-        Which agent's state should be updated.
+        The identifier of the agent whose state should be updated or
+        evaluated (e.g. ``"subject"``).
     view : DecisionTrialView
-        View built from the event payload and accumulated INPUT context.
+        A complete summary of the decision moment, ready for the model.
 
     Raises
     ------
     ValueError
-        If the trial fails schema validation.
+        If the trial's events do not match the expected schema structure.
     """
 
     schema.validate_trial(trial)
@@ -103,7 +145,8 @@ def replay_trial_steps(
     events = trial.events
     steps = schema.steps
 
-    actor_inputs: dict[str, Any] = {}  # most recent INPUT event per actor
+    # Most recent INPUT event per actor — used to recover available_actions.
+    actor_inputs: dict[str, Any] = {}
 
     for event, step in zip(events, steps, strict=True):
         if step.phase == EventPhase.INPUT:
@@ -127,7 +170,8 @@ def replay_trial_steps(
                 )
 
         elif step.phase == EventPhase.OUTCOME:
-            pass  # reward flows into the following UPDATE event payload
+            # Reward flows directly into the UPDATE event payload below.
+            pass
 
         elif step.phase == EventPhase.UPDATE:
             learner = step.learner_id

--- a/src/comp_model/data/schema.py
+++ b/src/comp_model/data/schema.py
@@ -1,9 +1,20 @@
-"""Canonical hierarchical data structures for the modeling package.
+"""How experimental data is organized in this package.
 
-The repository-wide source of truth is the event hierarchy
-``Event -> Trial -> Block -> SubjectData -> Dataset``. Simulation,
-validation, replay likelihoods, and Stan export all work from these objects
-rather than from a separate flattened table representation.
+Every piece of data — whether collected from a real participant or generated
+by a simulation — is stored as nested containers that mirror the natural
+structure of an experiment:
+
+    Event  →  one thing that happened (e.g. a choice was made, a reward was shown)
+    Trial  →  one complete round of the task (a sequence of events)
+    Block  →  a group of trials that share the same condition or context
+    SubjectData  →  everything one participant did across all blocks
+    Dataset  →  all participants in a study
+
+This hierarchy is the single source of truth for the whole package. Model
+fitting, simulation, and data export all work from these objects rather than
+from a separate flat spreadsheet-style representation. Keeping one
+authoritative structure means that every analysis tool sees data in the same
+format.
 """
 
 from __future__ import annotations
@@ -19,24 +30,34 @@ if TYPE_CHECKING:
 
 
 class EventPhase(StrEnum):
-    """Ordered phase labels for fit-relevant trial events.
+    """The four stages of a single decision cycle.
 
-    Attributes
-    ----------
+    Each trial is broken into ordered stages that reflect what is happening
+    cognitively at that moment. Together they form a decision cycle:
+
     INPUT
-        Information entering the modeled agent before a choice.
+        The participant sees the available options (e.g. which buttons they
+        can press, what stimuli are on screen). This is the information the
+        model uses to set up the choice.
     DECISION
-        A choice emitted by an actor.
+        A choice is made — either by the participant or by a demonstrator
+        being observed. The payload records which action was taken.
     OUTCOME
-        Scalar outcome associated with a decision point.
+        The result of the choice is revealed (e.g. a reward is shown). This
+        stage exists as a record of what happened but the reward value itself
+        is forwarded into the UPDATE payload so the model does not need to
+        piece it together from two separate events.
     UPDATE
-        Explicit learning/update marker for the modeled agent.
+        Learning happens here. The model uses this event to revise its
+        internal beliefs or action values. Crucially, *where* this event
+        appears in the trial sequence controls *when* learning fires relative
+        to the rest of the trial — placing it before or after other events
+        changes the order in which the model updates.
 
-    Notes
-    -----
-    The phase vocabulary is intentionally generic. Task-specific semantics such as
-    "social observation before choice" are encoded by event order, ``actor_id``,
-    and ``node_id``, not by introducing task-specific phase enums.
+    These labels are intentionally generic. Whether an INPUT event refers to
+    "social cues before a choice" or "stimulus onset" is encoded by the
+    sequence of events and the actor labels, not by adding task-specific
+    phase names.
     """
 
     INPUT = "input"
@@ -47,27 +68,40 @@ class EventPhase(StrEnum):
 
 @dataclass(frozen=True, slots=True)
 class Event:
-    """Atomic ordered event within a trial.
+    """The smallest unit of recorded data: one thing that happened.
+
+    Every moment worth recording in a trial is stored as an Event. What the
+    event actually contains depends on its phase:
+
+    - An INPUT event might carry ``{"available_actions": [0, 1, 2]}``
+      (the options the participant was shown).
+    - A DECISION event carries ``{"action": 1}`` (the choice that was made).
+    - An OUTCOME event carries ``{"reward": 1.0}`` (what the participant received).
+    - An UPDATE event carries both ``{"choice": 1, "reward": 1.0}`` so the
+      model has everything it needs in one place.
 
     Attributes
     ----------
     phase
-        Structural phase of the event.
+        Which stage of the decision cycle this event belongs to
+        (INPUT, DECISION, OUTCOME, or UPDATE).
     event_index
-        Zero-based position within the containing trial.
+        The position of this event within the trial (0 = first event).
     node_id
-        Identifier linking events that belong to the same decision point.
+        A label that groups the INPUT, DECISION, OUTCOME, and UPDATE events
+        that all belong to the same choice point. For example, in a task
+        where the participant first watches a demonstrator and then makes
+        their own choice, the demonstrator's events and the participant's
+        events each get their own ``node_id`` so it is always clear which
+        events go together. Using a shared label avoids hard-coding
+        domain-specific names like ``"social"`` or ``"self"``.
     actor_id
-        Identifier for the actor associated with the event.
+        Who produced this event. Use ``"subject"`` for the participant's
+        own actions and ``"demonstrator"`` (or any other label) for another
+        agent being observed. Defaults to ``"subject"``.
     payload
-        Phase-specific data carried by the event.
-
-    Notes
-    -----
-    ``node_id`` is structural rather than semantic. It links the INPUT,
-    DECISION, OUTCOME, and UPDATE events that belong to the same decision point
-    without requiring hard-coded domain labels such as ``"social"`` or
-    ``"stimulus"``.
+        The data carried by this event. Its contents depend on the phase
+        (see examples above).
     """
 
     phase: EventPhase
@@ -79,21 +113,23 @@ class Event:
 
 @dataclass(frozen=True, slots=True)
 class Trial:
-    """Ordered event sequence for one trial.
+    """One complete round of the task.
+
+    A Trial contains the full sequence of events that occurred during a single
+    round: seeing the options, making a choice, receiving a reward, and
+    updating. The events are stored in the order they happened so that
+    replaying the trial faithfully reproduces the sequence the model would
+    have experienced.
 
     Attributes
     ----------
     trial_index
-        Zero-based index within the containing block.
+        Which round this was within the current block (0 = first trial).
     events
-        Ordered events emitted during the trial.
+        The ordered events that make up this trial.
     metadata
-        Optional trial-level metadata.
-
-    Notes
-    -----
-    Trials do not include synthetic ``BLOCK_START`` or ``BLOCK_END`` events.
-    Block boundaries are represented explicitly by :class:`Block`.
+        Any extra information about this trial (e.g. reaction times,
+        condition labels) that does not fit into the event structure.
     """
 
     trial_index: int
@@ -103,23 +139,28 @@ class Trial:
 
 @dataclass(frozen=True, slots=True)
 class Block:
-    """Group of trials sharing a condition or other shared metadata.
+    """A group of consecutive trials that share the same experimental condition.
+
+    In most learning experiments, participants complete multiple blocks where
+    the task context changes between blocks (e.g. different reward
+    probabilities, different partners, or a context switch). A Block groups
+    the trials that belong to one such period.
+
+    Blocks also serve as natural reset points: if a model is configured to
+    reset its learned values at the start of each new context, that reset
+    happens at the Block boundary.
 
     Attributes
     ----------
     block_index
-        Zero-based block index within a subject.
+        Which block this is for this participant (0 = first block).
     condition
-        Condition label for the block.
+        A label describing the experimental condition for this block
+        (e.g. ``"high_volatility"`` or ``"social"``).
     trials
-        Ordered trials belonging to the block.
+        The trials that make up this block, in order.
     metadata
-        Optional block-level metadata.
-
-    Notes
-    -----
-    A block is the structural unit that determines condition changes and, when a
-    kernel opts into ``state_reset_policy="per_block"``, latent-state resets.
+        Any extra information about this block.
     """
 
     block_index: int
@@ -130,21 +171,22 @@ class Block:
 
 @dataclass(frozen=True, slots=True)
 class SubjectData:
-    """Hierarchical data for one subject.
+    """Everything one participant did across the entire experiment.
+
+    This container holds all the blocks (and therefore all the trials and
+    events) for a single participant, in the order they were experienced.
+    The ordering matters: when the model is fit to a participant's data, it
+    replays the blocks in sequence, just as the participant lived through them.
 
     Attributes
     ----------
     subject_id
-        Subject identifier unique within a dataset.
+        A unique identifier for this participant within the dataset
+        (e.g. ``"sub-01"``).
     blocks
-        Ordered blocks completed by the subject.
+        The blocks the participant completed, in chronological order.
     metadata
-        Optional subject-level metadata.
-
-    Notes
-    -----
-    The order of ``blocks`` is semantically important. Replay and simulation
-    assume it reflects the real sequence experienced by the subject.
+        Any extra participant-level information (e.g. age, group assignment).
     """
 
     subject_id: str
@@ -152,13 +194,18 @@ class SubjectData:
     metadata: Mapping[str, Any] = field(default_factory=empty_mapping)
 
     def iter_block_trials(self) -> Iterator[tuple[Block, Trial]]:
-        """Yield each trial together with its containing block.
+        """Step through every trial for this participant, one at a time.
+
+        Yields each trial paired with the block it belongs to, in the order
+        the participant experienced them. Having the block alongside the trial
+        is useful when the model needs to know the current condition or when
+        block boundaries trigger a state reset.
 
         Yields
         ------
         tuple[Block, Trial]
-            Each block-trial pair in hierarchical order, preserving the exact
-            replay order used by likelihood code.
+            A (block, trial) pair for every trial across all blocks, in
+            chronological order.
         """
 
         for block in self.blocks:
@@ -167,13 +214,16 @@ class SubjectData:
 
     @property
     def trials(self) -> tuple[Trial, ...]:
-        """Flatten trials across all blocks.
+        """All of this participant's trials as a simple flat list.
+
+        A convenience shortcut when you want to iterate over every trial
+        without needing to know which block each trial came from. The trials
+        are returned in the same chronological order as they were experienced.
 
         Returns
         -------
         tuple[Trial, ...]
-            Trial records in block order. This is a convenience view rather than
-            the primary ontology.
+            Every trial this participant completed, across all blocks, in order.
         """
 
         return tuple(trial for block in self.blocks for trial in block.trials)
@@ -181,19 +231,25 @@ class SubjectData:
 
 @dataclass(frozen=True, slots=True)
 class Dataset:
-    """Collection of subjects plus optional study-level metadata.
+    """The whole study: every participant and all their data.
+
+    A Dataset is the top-level container that holds data for all participants
+    in a study. It is typically what you load at the start of an analysis and
+    pass to fitting or simulation routines.
+
+    The helper properties ``blocks`` and ``trials`` let you quickly access all
+    blocks or all trials across every participant in a consistent, predictable
+    order (participant by participant, then block by block within each
+    participant). This consistent ordering ensures that indices stay aligned
+    when exporting to analysis tools.
 
     Attributes
     ----------
     subjects
-        Ordered subject records in the dataset.
+        All participants in the dataset, in a fixed order.
     metadata
-        Optional dataset-level metadata.
-
-    Notes
-    -----
-    Dataset-level helper properties preserve subject-major ordering so that
-    downstream exporters can reconstruct subject and block indices deterministically.
+        Any study-level information (e.g. study name, date collected,
+        task version).
     """
 
     subjects: tuple[SubjectData, ...]
@@ -201,24 +257,32 @@ class Dataset:
 
     @property
     def blocks(self) -> tuple[Block, ...]:
-        """Flatten blocks across all subjects.
+        """All blocks in the dataset as a simple flat list.
+
+        Returns every block from every participant, ordered participant by
+        participant. Useful for quickly iterating over experimental conditions
+        across the whole study.
 
         Returns
         -------
         tuple[Block, ...]
-            Blocks in subject-major order.
+            Every block from all participants, in participant order.
         """
 
         return tuple(block for subject in self.subjects for block in subject.blocks)
 
     @property
     def trials(self) -> tuple[Trial, ...]:
-        """Flatten trials across all subjects and blocks.
+        """All trials in the dataset as a simple flat list.
+
+        Returns every trial from every participant and every block in a single
+        sequence. The order goes participant by participant, and within each
+        participant block by block — matching the order trials were experienced.
 
         Returns
         -------
         tuple[Trial, ...]
-            Trials in subject-major, then block-major order.
+            Every trial from all participants, in participant-then-block order.
         """
 
         return tuple(

--- a/src/comp_model/models/kernels/asocial_q_learning.py
+++ b/src/comp_model/models/kernels/asocial_q_learning.py
@@ -1,7 +1,22 @@
 """Asocial Q-learning kernel.
 
-This kernel implements a standard Rescorla-Wagner update with softmax action
-selection over latent action values.
+This module implements the classic Q-learning (Rescorla-Wagner) model for a
+single agent learning on their own, with no social information.
+
+The core idea is simple: the agent keeps an internal estimate of how good each
+option is (called a Q-value). After each trial the estimate for the chosen
+option is nudged toward the reward that was actually received. Over many trials
+the estimates converge toward the true reward probabilities of each option.
+
+Two free parameters control the agent's behaviour:
+
+- ``alpha`` (learning rate): how much weight the agent gives to new evidence.
+  A high alpha means recent outcomes dominate; a low alpha means the agent
+  updates slowly and relies heavily on accumulated past experience.
+- ``beta`` (inverse temperature): how deterministically the agent exploits its
+  best option. A high beta means the agent almost always picks the option with
+  the highest Q-value; a low beta means choices are near-random regardless of
+  Q-values.
 """
 
 from __future__ import annotations
@@ -19,14 +34,20 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, slots=True)
 class QParams:
-    """Parsed parameters for the asocial Q-learning kernel.
+    """The two free parameters that define an asocial Q-learning agent.
 
     Attributes
     ----------
     alpha
-        Learning rate in `(0, 1)`.
+        Learning rate — a number strictly between 0 and 1. Controls how quickly
+        the agent updates its beliefs after each outcome. A value near 1 means
+        the agent almost replaces its old estimate with the new reward; a value
+        near 0 means the agent changes its estimate very little each trial.
     beta
-        Inverse temperature in `(0, +inf)`.
+        Inverse temperature — a positive number. Controls how deterministically
+        the agent acts on its beliefs. A large beta means the agent reliably
+        picks the option it currently thinks is best; a small beta means choices
+        are more random and exploratory.
     """
 
     alpha: float
@@ -35,38 +56,48 @@ class QParams:
 
 @dataclass(slots=True)
 class QState:
-    """Latent Q-values for an asocial learning agent.
+    """The agent's current internal beliefs — one value per available option.
+
+    Each Q-value is the agent's running estimate of how rewarding a particular
+    option is. Q-values are updated trial by trial as the agent gains
+    experience. They start at 0.5 (reflecting genuine uncertainty) and drift
+    toward 0 or 1 as evidence accumulates.
 
     Attributes
     ----------
     q_values
-        Per-action Q-values indexed by action value.
+        List of Q-values, one per option, indexed by the option's integer code.
+        For example, if there are two options, ``q_values[0]`` is the current
+        estimate for option 0 and ``q_values[1]`` for option 1.
     """
 
     q_values: list[float]
 
 
 class AsocialQLearningKernel:
-    """Standard softmax Q-learning kernel for asocial bandit tasks.
+    """Q-learning model for a participant who learns only from their own experience.
 
-    Notes
-    -----
-    The kernel is schema-agnostic. It relies only on the extracted
-    :class:`~comp_model.data.extractors.DecisionTrialView`, so the same kernel
-    can be replayed against any task schema that yields compatible asocial
-    decision views.
+    This is the standard asocial reinforcement learning model. The agent
+    observes the options available on each trial, makes a choice, receives a
+    reward, and updates only the Q-value for the option they actually chose.
+    Options not chosen on a given trial are left unchanged.
+
+    The same kernel works with any task design that produces a compatible trial
+    record — it does not depend on the specifics of how a particular experiment
+    was structured.
     """
 
     @classmethod
     def spec(cls) -> ModelKernelSpec:
-        """Return static metadata for the asocial kernel.
+        """Return a description of this model's parameters for the fitting machinery.
 
         Returns
         -------
         ModelKernelSpec
-            Static kernel specification declaring two parameters:
-            ``alpha`` on the unit interval and ``beta`` on the positive real
-            line.
+            A record declaring this model's two free parameters (``alpha`` and
+            ``beta``), how each is constrained (alpha to (0, 1); beta to
+            positive values), and sensible starting values for numerical
+            optimisation.
         """
 
         return ModelKernelSpec(
@@ -98,17 +129,25 @@ class AsocialQLearningKernel:
         )
 
     def parse_params(self, raw: dict[str, float]) -> QParams:
-        """Transform unconstrained parameters into typed kernel parameters.
+        """Convert raw optimiser values into interpretable model parameters.
+
+        During fitting, the optimiser works with unconstrained real-valued
+        numbers (which can range from -infinity to +infinity). This method
+        applies the appropriate mathematical transformations to map those raw
+        numbers back onto their meaningful scales: alpha is squeezed into (0, 1)
+        and beta is mapped to a positive value.
 
         Parameters
         ----------
         raw
-            Unconstrained parameter values keyed by parameter name.
+            Dictionary of unconstrained parameter values produced by the
+            optimiser, keyed by parameter name.
 
         Returns
         -------
         QParams
-            Typed parameter object after applying the shared transform registry.
+            Parameter object with alpha and beta on their natural scales,
+            ready for use in ``action_probabilities`` and ``next_state``.
         """
 
         return QParams(
@@ -117,19 +156,24 @@ class AsocialQLearningKernel:
         )
 
     def initial_state(self, n_actions: int, params: QParams) -> QState:
-        """Construct the initial latent Q-state.
+        """Create the agent's belief state at the very start of the task.
+
+        Before the first trial the agent has no experience, so all options are
+        assumed equally rewarding. Each Q-value is initialised to 0.5,
+        representing neutral uncertainty on a 0-1 reward scale.
 
         Parameters
         ----------
         n_actions
-            Number of legal actions in the task.
+            The number of options available in the task.
         params
-            Parsed kernel parameters.
+            The agent's fitted parameters (not used for initialisation, but
+            required by the shared interface).
 
         Returns
         -------
         QState
-            Initial Q-values set to ``0.5``.
+            A state with all Q-values set to 0.5.
         """
 
         del params
@@ -141,28 +185,32 @@ class AsocialQLearningKernel:
         view: DecisionTrialView,
         params: QParams,
     ) -> tuple[float, ...]:
-        """Compute softmax action probabilities for the current state.
+        """Compute the model's predicted probability of each available choice.
+
+        This is the softmax decision rule. The agent's Q-value for each
+        available option is multiplied by beta (the inverse temperature) and
+        then passed through the softmax function, which converts the scaled
+        Q-values into a proper probability distribution that sums to 1. A
+        higher Q-value produces a higher choice probability; beta controls the
+        steepness of that relationship.
+
+        Only the options that are actually available on the current trial are
+        scored — unavailable options are ignored.
 
         Parameters
         ----------
         state
-            Current latent Q-values.
+            The agent's current Q-values (beliefs about each option).
         view
-            Extracted decision record.
+            The trial record, including which options were available.
         params
-            Parsed kernel parameters.
+            The agent's fitted parameters (alpha and beta).
 
         Returns
         -------
         tuple[float, ...]
-            Probabilities aligned with ``view.available_actions``.
-
-        Notes
-        -----
-        The kernel scores only the currently legal actions, multiplies their
-        latent values by ``beta``, and normalizes them with a numerically stable
-        softmax. The returned tuple is aligned exactly with the order of
-        ``view.available_actions``.
+            Predicted choice probabilities in the same order as
+            ``view.available_actions``.
         """
 
         logits = [params.beta * state.q_values[action] for action in view.available_actions]
@@ -174,29 +222,36 @@ class AsocialQLearningKernel:
         view: DecisionTrialView,
         params: QParams,
     ) -> QState:
-        """Update the chosen action's Q-value from reward prediction error.
+        """Update beliefs after observing the outcome of a trial.
+
+        This implements the Rescorla-Wagner (delta rule) update. The agent
+        compares the reward they actually received to the reward they expected
+        (their current Q-value). The difference — called the prediction error —
+        is multiplied by alpha and added to the Q-value:
+
+            Q[chosen] = Q[chosen] + alpha * (reward_received - Q[chosen])
+
+        If the reward was better than expected, the Q-value goes up. If it was
+        worse, it goes down. Only the Q-value of the chosen option is changed;
+        all other options remain exactly as they were.
+
+        If no reward is recorded for this trial (e.g. some task designs omit
+        feedback on certain trials), the Q-values are returned unchanged.
 
         Parameters
         ----------
         state
-            Current latent Q-values.
+            The agent's Q-values before this trial's outcome.
         view
-            Extracted decision record.
+            The trial record, including the chosen option and the reward
+            received.
         params
-            Parsed kernel parameters.
+            The agent's fitted parameters (alpha controls the update size).
 
         Returns
         -------
         QState
-            Updated latent state.
-
-        Notes
-        -----
-        When a reward is present, the chosen action is updated according to
-
-        ``Q[a] <- Q[a] + alpha * (reward - Q[a])``.
-
-        Unchosen actions are left unchanged.
+            Updated Q-values to carry forward into the next trial.
         """
 
         updated_q_values = list(state.q_values)

--- a/src/comp_model/models/kernels/base.py
+++ b/src/comp_model/models/kernels/base.py
@@ -1,8 +1,26 @@
-"""Backend-agnostic kernel metadata and protocols.
+"""Definitions of what a computational model ("kernel") must be able to do.
 
-The kernel layer defines learning and choice rules only. It is deliberately
-agnostic to task structure, trial schemas, pooling hierarchies, and Stan
-implementation details.
+A "kernel" is the core of a computational model: it encodes the learning
+rule and the choice rule for a single participant. Every kernel must answer
+exactly three questions:
+
+1. What is the participant's internal state at the very start of the task
+   (e.g. Q-values all equal to 0.5)?
+2. Given the participant's current internal state, what is the probability
+   of each available action on this trial?
+3. After the participant chooses and receives an outcome, what is their
+   updated internal state?
+
+This module defines the shared interface (``ModelKernel``) that every kernel
+must implement, plus supporting metadata classes that describe a kernel's
+parameters and how the fitting machinery should handle them.
+
+Kernels are deliberately kept separate from task structure and fitting
+details. A kernel only ever sees a compact summary of one decision trial
+(a ``DecisionTrialView``). It never inspects raw events, trial schemas, or
+any fitting-backend specifics (e.g. Stan code). This separation means you
+can swap fitting backends without changing the model, and define new models
+without touching the infrastructure.
 """
 
 from __future__ import annotations
@@ -18,21 +36,32 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, slots=True)
 class InitSpec:
-    """Initialization metadata for MLE optimization.
+    """Instructions for where to start searching for a parameter's best-fitting value.
+
+    When fitting a model by maximum likelihood (MLE), the optimiser needs a
+    starting point for each parameter. This class records that starting point
+    and the strategy used to generate it.
+
+    Starting values are specified on an *unconstrained* scale — a mathematical
+    trick that lets the optimiser search over all real numbers even when the
+    actual parameter has a restricted range (e.g. learning rate must be
+    between 0 and 1). The transform specified on the matching
+    :class:`ParameterSpec` converts the unconstrained value back to the
+    meaningful scale (e.g. unconstrained 0.0 → learning rate 0.5 via the
+    sigmoid function).
 
     Attributes
     ----------
     strategy
-        Initialization strategy identifier.
+        A label identifying how starting values should be generated
+        (e.g. fixed point, random perturbation).
     kwargs
-        Strategy-specific keyword arguments.
+        Extra settings consumed by the chosen strategy.
     default_unconstrained
-        Default unconstrained starting value.
-
-    Notes
-    -----
-    Initialization is expressed on the unconstrained scale so that restart
-    generation is aligned with the kernel's transform registry.
+        The default starting value on the unconstrained scale.
+        Defaults to 0.0, which maps to 0.5 under a sigmoid transform —
+        a neutral, uninformed starting point for parameters bounded between
+        0 and 1.
     """
 
     strategy: str
@@ -42,24 +71,38 @@ class InitSpec:
 
 @dataclass(frozen=True, slots=True)
 class ParameterSpec:
-    """Metadata for one free model parameter.
+    """Description of one free parameter in the model.
+
+    Each free parameter — for example a learning rate or an inverse
+    temperature — has a ``ParameterSpec`` that tells the fitting machinery
+    everything it needs to know: what the parameter is called, how to
+    transform raw (unconstrained) values into meaningful (constrained) values,
+    and where to start searching during optimisation.
 
     Attributes
     ----------
     name
-        Parameter name exposed to inference code.
+        The parameter's name as it appears in results tables and in code
+        (e.g. ``"alpha"`` for a learning rate).
     transform_id
-        Identifier in the transform registry.
-    description
-        Human-readable description of the parameter.
-    mle_init
-        Optional initialization metadata for MLE.
+        A short label that points to the mathematical function used to map
+        unconstrained numbers onto the parameter's valid range. Two common
+        examples:
 
-    Notes
-    -----
-    ``transform_id`` links the parameter to the shared transform registry. That
-    single identifier drives constrained parsing in Python and transformed
-    parameter expressions in Stan.
+        - ``"sigmoid"``: maps any real number to the interval (0, 1),
+          suitable for rates and probabilities.
+        - ``"softplus"``: maps any real number to positive values,
+          suitable for parameters that must be greater than zero.
+
+        The same label is used both when parsing parameters in Python and
+        when generating the corresponding Stan code, so changing it updates
+        both simultaneously.
+    description
+        A plain-English explanation of what the parameter represents, used
+        in documentation and model summaries.
+    mle_init
+        Optional instructions for the starting point used during maximum
+        likelihood fitting. If ``None``, a default starting point is used.
     """
 
     name: str
@@ -70,29 +113,48 @@ class ParameterSpec:
 
 @dataclass(frozen=True, slots=True)
 class ModelKernelSpec:
-    """Static metadata describing a model kernel.
+    """The identity card for a computational model.
+
+    This class holds all the static, descriptive information about a kernel
+    that the fitting and simulation infrastructure needs to discover: what the
+    model is called, what parameters it has, whether it needs social
+    information, and how it manages memory across task blocks.
+
+    Think of it as the "spec sheet" read by inference code before any data
+    are ever touched. The kernel itself (the actual learning and choice
+    equations) is defined separately; this class just describes it.
 
     Attributes
     ----------
     model_id
-        Stable identifier for the kernel.
+        A stable, unique name for the model (e.g. ``"rescorla_wagner"``).
+        Used as a key in result files and Stan code.
     parameter_specs
-        Ordered parameter metadata for the kernel.
+        An ordered list of :class:`ParameterSpec` objects, one per free
+        parameter. The order matters — it determines the order of columns
+        in parameter tables and of entries in Stan parameter blocks.
     requires_social
-        Whether the kernel reads social fields from decision views.
+        Set to ``True`` if this model uses information about another
+        agent's choices or outcomes (i.e. it is a social-learning model).
+        This tells the simulation engine and inference code to expect and
+        provide social fields.
     n_actions
-        Optional fixed action count. ``None`` means infer from data.
+        The number of response options the model expects. If ``None``,
+        this is inferred from the data. Override with a fixed integer if
+        the model has a hard-coded action count.
     state_reset_policy
-        Policy for resetting kernel state, either ``"per_subject"`` or ``"per_block"``.
-    description
-        Human-readable model description.
+        Controls how the model's internal state (e.g. Q-values) is
+        managed across task blocks:
 
-    Notes
-    -----
-    ``ModelKernelSpec`` does not reference event-order details such as
-    ``TrialSchema`` or ``node_id``. It describes the kernel's parameters and
-    replay requirements after extraction has already produced flat decision
-    views.
+        - ``"per_subject"``: state accumulates across all blocks;
+          learning carries over from one block to the next.
+        - ``"per_block"``: state is reset to initial values at the start
+          of each new block; each block begins with a blank slate.
+    initial_value
+        The starting value assigned to each Q-value (or equivalent
+        quantity) before any learning occurs. Defaults to 0.5.
+    description
+        A plain-English summary of the model, used in reports and logs.
     """
 
     model_id: str
@@ -109,60 +171,96 @@ ParamsT = TypeVar("ParamsT")
 
 
 class ModelKernel(Protocol, Generic[StateT, ParamsT]):
-    """Protocol shared by all backend-agnostic model kernels.
+    """The interface that every computational model must implement.
 
-    Notes
-    -----
-    Kernels only consume :class:`~comp_model.data.extractors.DecisionTrialView`
-    objects. They never inspect raw :class:`~comp_model.data.schema.Event`,
-    :class:`~comp_model.data.schema.Trial`, or
-    :class:`~comp_model.tasks.schemas.TrialSchema` objects.
+    A ``ModelKernel`` is the heart of a computational model. It encodes two
+    psychological mechanisms:
+
+    - **Learning rule**: how the participant updates their internal
+      representation of the world (e.g. Q-values) after each outcome.
+    - **Choice rule**: how the participant translates their current
+      representation into a probability distribution over available actions.
+
+    Every kernel must answer three questions (the three core methods):
+
+    1. :meth:`initial_state` — what is the participant's starting state?
+    2. :meth:`action_probabilities` — given the current state, how likely is
+       each action?
+    3. :meth:`next_state` — given the outcome, what is the updated state?
+
+    Two additional methods are needed by the fitting and simulation machinery:
+
+    - :meth:`spec` — returns the model's identity card
+      (:class:`ModelKernelSpec`).
+    - :meth:`parse_params` — converts raw numerical values from the optimiser
+      into the structured parameter object the model expects.
+
+    Kernels are deliberately kept narrow: they only ever see a compact summary
+    of one decision trial (:class:`~comp_model.data.extractors.DecisionTrialView`).
+    They never inspect raw event logs, trial schemas, or fitting-backend
+    details. This keeps the model definitions clean and portable.
     """
 
     @classmethod
     def spec(cls) -> ModelKernelSpec:
-        """Return static kernel metadata.
+        """Return the identity card (static metadata) for this model.
 
         Returns
         -------
         ModelKernelSpec
-            Kernel specification used by inference code.
+            Describes the model's name, free parameters, social requirements,
+            and state reset policy. Read by simulation and inference code
+            before any data are processed.
         """
 
         ...
 
     def parse_params(self, raw: dict[str, float]) -> ParamsT:
-        """Convert unconstrained parameter values into typed parameters.
+        """Convert raw numbers from the optimiser into this model's parameter object.
+
+        The optimiser works with plain floating-point numbers, often on an
+        unconstrained scale. This method applies the appropriate transforms
+        (e.g. sigmoid for learning rate, softplus for inverse temperature)
+        and packages the result into the typed parameter structure the model
+        uses internally.
 
         Parameters
         ----------
         raw
-            Raw unconstrained parameter values keyed by parameter name.
+            A dictionary mapping parameter names to their current
+            unconstrained values (as supplied by the optimiser or sampler).
 
         Returns
         -------
         ParamsT
-            Parsed parameter object for the kernel, typically after applying the
-            parameter transform specified in :class:`ParameterSpec`.
+            A typed parameter object ready to be passed to
+            :meth:`initial_state`, :meth:`action_probabilities`, and
+            :meth:`next_state`.
         """
 
         ...
 
     def initial_state(self, n_actions: int, params: ParamsT) -> StateT:
-        """Construct the initial latent state.
+        """Create the participant's blank starting state before any learning.
+
+        Called once at the beginning of the task (and again at the start of
+        each block if ``state_reset_policy == "per_block"``). Typically
+        initialises Q-values or other internal quantities to their prior
+        values.
 
         Parameters
         ----------
         n_actions
-            Number of legal actions in the task.
+            How many response options exist in the task (e.g. 2 for a
+            two-armed bandit).
         params
-            Parsed kernel parameters.
+            The participant's parameter values, which may influence the
+            starting state (e.g. an initial-value parameter).
 
         Returns
         -------
         StateT
-            Initial latent state used at subject start or, when configured, at
-            each block boundary.
+            The initial internal state, ready for the first trial.
         """
 
         ...
@@ -173,22 +271,29 @@ class ModelKernel(Protocol, Generic[StateT, ParamsT]):
         view: DecisionTrialView,
         params: ParamsT,
     ) -> tuple[float, ...]:
-        """Return action probabilities for the current decision view.
+        """Compute the probability of each available action on this trial.
+
+        This is the choice rule. It translates the participant's current
+        internal state (e.g. Q-values) into a probability distribution over
+        actions, typically using a softmax function governed by the inverse
+        temperature parameter.
 
         Parameters
         ----------
         state
-            Current latent state.
+            The participant's current internal state (e.g. Q-values).
         view
-            Extracted decision record.
+            A compact summary of the current decision trial, including which
+            actions are available and the trial index.
         params
-            Parsed kernel parameters.
+            The participant's parameter values.
 
         Returns
         -------
         tuple[float, ...]
-            Probabilities aligned with ``view.available_actions`` only. Illegal
-            actions must not appear in the returned tuple.
+            A probability for each action in ``view.available_actions``,
+            in the same order. Probabilities sum to 1. Only available actions
+            appear; unavailable actions are excluded entirely.
         """
 
         ...
@@ -199,22 +304,28 @@ class ModelKernel(Protocol, Generic[StateT, ParamsT]):
         view: DecisionTrialView,
         params: ParamsT,
     ) -> StateT:
-        """Update the latent state after the decision outcome.
+        """Update the participant's internal state after observing an outcome.
+
+        This is the learning rule. It incorporates the new information from
+        the trial (e.g. reward received, or a demonstrator's choice) and
+        returns the updated state that will be used on the next trial.
 
         Parameters
         ----------
         state
-            Current latent state.
+            The participant's internal state before this update.
         view
-            Extracted decision record.
+            A compact summary of the trial outcome, containing the choice
+            made, the reward received, and (for social-learning models) the
+            demonstrator's choice and reward if available.
         params
-            Parsed kernel parameters.
+            The participant's parameter values.
 
         Returns
         -------
         StateT
-            Updated latent state after incorporating any outcome or social
-            information present in ``view``.
+            The updated internal state, incorporating whatever information
+            was present in ``view``.
         """
 
         ...

--- a/src/comp_model/models/kernels/probabilities.py
+++ b/src/comp_model/models/kernels/probabilities.py
@@ -1,4 +1,4 @@
-"""Shared probability utilities for model kernels."""
+"""Shared probability utilities used by all model kernels."""
 
 from __future__ import annotations
 
@@ -11,29 +11,42 @@ if TYPE_CHECKING:
 
 
 def stable_softmax(logits: Sequence[float]) -> tuple[float, ...]:
-    """Compute a numerically stable softmax over one-dimensional logits.
+    """Convert a list of raw scores into a proper probability distribution.
+
+    The softmax function takes one score per option and returns one probability
+    per option such that all probabilities are positive and sum to exactly 1.
+    An option with a higher score gets a higher probability. The transformation
+    is non-linear: doubling a score does not double its probability.
+
+    "Stable" refers to two numerical precautions that prevent computational
+    problems:
+
+    1. Before exponentiating, the largest score is subtracted from all scores.
+       This does not change the resulting probabilities (the ratio cancels) but
+       prevents the exponential from producing infinitely large numbers when
+       scores are large.
+
+    2. After computing the probabilities, any value that rounds down to
+       exactly 0 is replaced with a tiny positive number (1e-15). This matters
+       because model fitting requires computing the logarithm of each choice
+       probability, and log(0) is negative infinity, which breaks optimisation.
 
     Parameters
     ----------
     logits
-        One-dimensional sequence of logit values.
+        The raw scores, one per option. In this codebase these are Q-values
+        multiplied by the inverse temperature (beta * Q[action]).
 
     Returns
     -------
     tuple[float, ...]
-        Softmax probabilities summing to one.
+        Probabilities in the same order as the input scores, all positive and
+        summing to 1.
 
     Raises
     ------
     ValueError
-        Raised when ``logits`` is empty.
-
-    Notes
-    -----
-    The implementation subtracts the maximum logit before exponentiation, then
-    clips the resulting probabilities away from exactly zero before
-    renormalizing. That keeps replay likelihoods finite when downstream code
-    takes logarithms of action probabilities.
+        Raised when the input list is empty.
     """
 
     logits_array = np.asarray(tuple(logits), dtype=float)

--- a/src/comp_model/models/kernels/social_rl_self_reward_demo_reward.py
+++ b/src/comp_model/models/kernels/social_rl_self_reward_demo_reward.py
@@ -1,8 +1,22 @@
-"""Social RL kernel updating from self reward and demonstrator reward.
+"""Social reinforcement learning kernel — learning from own outcomes and from a demonstrator.
 
-This kernel extends the asocial RL update with a second learning rate for
-observed demonstrator outcomes. The demonstrator's action is used only as an
-index to identify which Q-value to update.
+This module extends the basic Q-learning model to capture social learning.
+A participant in a social learning experiment can update their beliefs in two
+distinct ways on each trial:
+
+1. From their own experience: after receiving a reward, they update their
+   estimate of the option they personally chose (controlled by ``alpha_self``).
+2. From the demonstrator's experience: after observing the demonstrator's
+   choice and reward, they update their estimate of the option the demonstrator
+   chose (controlled by ``alpha_other``).
+
+The two updates are independent — both can occur in the same trial, or either
+one can occur alone, depending on what information was available.
+
+This model is useful for quantifying how much weight a participant gives to
+social information relative to their own direct experience. A participant with
+a large ``alpha_other`` relative to ``alpha_self`` is a strong social learner;
+one with ``alpha_other`` near zero largely ignores the demonstrator.
 """
 
 from __future__ import annotations
@@ -20,16 +34,26 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, slots=True)
 class SocialRlSelfRewardDemoRewardParams:
-    """Parsed parameters for the social self-reward + demo-reward kernel.
+    """The three free parameters that define a social Q-learning agent.
 
     Attributes
     ----------
     alpha_self
-        Learning rate for self-generated outcomes.
+        Self learning rate — a number strictly between 0 and 1. Controls how
+        much the participant updates their beliefs from their own reward on each
+        trial. Identical in meaning to the ``alpha`` parameter in the asocial
+        Q-learning model.
     alpha_other
-        Learning rate for demonstrator outcomes.
+        Social learning rate — a number strictly between 0 and 1. Controls how
+        much the participant updates their beliefs from the demonstrator's
+        reward. A value near 1 means the participant treats the demonstrator's
+        outcome almost as strongly as their own; a value near 0 means the
+        participant nearly ignores what the demonstrator experienced.
     beta
-        Inverse temperature for choice stochasticity.
+        Inverse temperature — a positive number. Controls how deterministically
+        the participant acts on their current beliefs when choosing between
+        options. Identical in meaning to the ``beta`` parameter in the asocial
+        model.
     """
 
     alpha_self: float
@@ -39,40 +63,62 @@ class SocialRlSelfRewardDemoRewardParams:
 
 @dataclass(slots=True)
 class SocialRlSelfRewardDemoRewardState:
-    """Latent state for a social self-reward + demo-reward agent.
+    """The agent's current internal beliefs — one value per available option.
+
+    Structurally identical to the asocial ``QState``: a list of Q-values, one
+    per option, representing the agent's current estimate of each option's
+    reward. The difference is that these values can be updated by both the
+    agent's own experience and by observed demonstrator experience.
 
     Attributes
     ----------
     q_values
-        Per-action Q-values indexed by action value.
+        List of Q-values, one per option, indexed by the option's integer code.
+        All values start at 0.5 and shift trial by trial as the agent
+        accumulates self-generated and socially observed evidence.
     """
 
     q_values: list[float]
 
 
 class SocialRlSelfRewardDemoRewardKernel:
-    """Social RL kernel that updates from self reward and demonstrator reward.
+    """Q-learning model for a participant who learns from both personal and social experience.
 
-    Notes
-    -----
-    The demonstrator's action is used only as an index identifying which
-    Q-value to update with the demonstrator's reward. The active learning
-    signals are the self reward and the demonstrator reward; the demonstrator
-    action carries no independent learning signal.
+    On each trial this model can update the participant's beliefs in two ways:
 
-    Whether demonstrator information appeared before the subject's choice or
-    after the outcome is a schema concern handled by extraction.
+    - Personal update: if the participant received a reward, the Q-value for
+      the option they chose is nudged toward that reward using ``alpha_self``.
+    - Social update: if the demonstrator's choice and reward are available, the
+      Q-value for the option the demonstrator chose is nudged toward the
+      demonstrator's reward using ``alpha_other``.
+
+    The two updates are applied independently. Both can fire on the same trial
+    (e.g. the participant both acted themselves and observed the demonstrator),
+    or either one can fire alone.
+
+    Note: the demonstrator's choice matters only to indicate *which* Q-value
+    gets the social update. It is the demonstrator's *reward* that drives
+    learning, not the fact that the demonstrator happened to pick a particular
+    option.
+
+    Whether the participant observes the demonstrator before or after their own
+    choice is determined by the experimental design (the trial schema), not by
+    this model. The model simply uses whatever social information is present in
+    the trial record.
     """
 
     @classmethod
     def spec(cls) -> ModelKernelSpec:
-        """Return static metadata for this kernel.
+        """Return a description of this model's parameters for the fitting machinery.
 
         Returns
         -------
         ModelKernelSpec
-            Static kernel specification declaring separate self and social
-            learning rates plus a shared inverse temperature.
+            A record declaring three free parameters (``alpha_self``,
+            ``alpha_other``, ``beta``), their constraints, and their starting
+            values for numerical optimisation. Also flags that this model
+            requires social information (demonstrator action and reward) to be
+            present in the trial data.
         """
 
         return ModelKernelSpec(
@@ -99,17 +145,22 @@ class SocialRlSelfRewardDemoRewardKernel:
         )
 
     def parse_params(self, raw: dict[str, float]) -> SocialRlSelfRewardDemoRewardParams:
-        """Transform unconstrained parameters into typed kernel parameters.
+        """Convert raw optimiser values into interpretable model parameters.
+
+        The optimiser works internally with unconstrained numbers. This method
+        applies the appropriate transformations to produce alpha_self and
+        alpha_other in (0, 1) and beta as a positive value.
 
         Parameters
         ----------
         raw
-            Unconstrained parameter values keyed by parameter name.
+            Dictionary of unconstrained parameter values produced by the
+            optimiser, keyed by parameter name.
 
         Returns
         -------
         SocialRlSelfRewardDemoRewardParams
-            Typed parameter object after applying the shared transform registry.
+            Parameter object with all three parameters on their natural scales.
         """
 
         return SocialRlSelfRewardDemoRewardParams(
@@ -121,19 +172,24 @@ class SocialRlSelfRewardDemoRewardKernel:
     def initial_state(
         self, n_actions: int, params: SocialRlSelfRewardDemoRewardParams
     ) -> SocialRlSelfRewardDemoRewardState:
-        """Construct the initial latent state.
+        """Create the agent's belief state at the very start of the task.
+
+        All Q-values are initialised to 0.5, reflecting neutral uncertainty
+        about every option before any personal or social experience has been
+        accumulated.
 
         Parameters
         ----------
         n_actions
-            Number of legal actions in the task.
+            The number of options available in the task.
         params
-            Parsed kernel parameters.
+            The agent's fitted parameters (not used for initialisation, but
+            required by the shared interface).
 
         Returns
         -------
         SocialRlSelfRewardDemoRewardState
-            Initial Q-values set to ``0.5``.
+            A state with all Q-values set to 0.5.
         """
 
         del params
@@ -145,21 +201,28 @@ class SocialRlSelfRewardDemoRewardKernel:
         view: DecisionTrialView,
         params: SocialRlSelfRewardDemoRewardParams,
     ) -> tuple[float, ...]:
-        """Compute softmax action probabilities for the current state.
+        """Compute the model's predicted probability of each available choice.
+
+        Identical in form to the asocial version: Q-values for the available
+        options are scaled by beta and converted to probabilities via softmax.
+        The Q-values here, however, reflect both self-generated and socially
+        observed experience (depending on what has occurred in prior trials).
 
         Parameters
         ----------
         state
-            Current latent state.
+            The agent's current Q-values (combining personal and social
+            learning history).
         view
-            Extracted decision record.
+            The trial record, including which options were available.
         params
-            Parsed kernel parameters.
+            The agent's fitted parameters.
 
         Returns
         -------
         tuple[float, ...]
-            Probabilities aligned with ``view.available_actions``.
+            Predicted choice probabilities in the same order as
+            ``view.available_actions``.
         """
 
         logits = [params.beta * state.q_values[action] for action in view.available_actions]
@@ -171,28 +234,41 @@ class SocialRlSelfRewardDemoRewardKernel:
         view: DecisionTrialView,
         params: SocialRlSelfRewardDemoRewardParams,
     ) -> SocialRlSelfRewardDemoRewardState:
-        """Update Q-values from self reward and demonstrator reward.
+        """Update beliefs after observing the outcomes of a trial.
+
+        Two independent updates may occur:
+
+        Personal update — if the participant received a reward on this trial,
+        the Q-value for their chosen option is updated using the Rescorla-Wagner
+        rule scaled by ``alpha_self``:
+
+            Q[own_choice] = Q[own_choice] + alpha_self * (own_reward - Q[own_choice])
+
+        Social update — if the demonstrator's choice and reward are both
+        available, the Q-value for the demonstrator's chosen option is updated
+        using the same rule scaled by ``alpha_other``:
+
+            Q[demo_choice] = Q[demo_choice] + alpha_other * (demo_reward - Q[demo_choice])
+
+        Either, both, or neither update can occur on any given trial, depending
+        on whether the corresponding information was present in the experimental
+        record.
 
         Parameters
         ----------
         state
-            Current latent state.
+            The agent's Q-values before this trial's outcomes.
         view
-            Extracted decision record.
+            The trial record, including the participant's choice and reward
+            (if present) and the demonstrator's choice and reward (if present).
         params
-            Parsed kernel parameters.
+            The agent's fitted parameters (alpha_self and alpha_other control
+            the respective update sizes).
 
         Returns
         -------
         SocialRlSelfRewardDemoRewardState
-            Updated latent state.
-
-        Notes
-        -----
-        The subject's chosen action is updated with ``alpha_self`` when a
-        reward is present. If demonstrator action and reward are both present,
-        the observed action is updated with ``alpha_other`` using the
-        demonstrator reward as the learning signal.
+            Updated Q-values to carry forward into the next trial.
         """
 
         updated_q_values = list(state.q_values)

--- a/src/comp_model/models/kernels/transforms.py
+++ b/src/comp_model/models/kernels/transforms.py
@@ -1,8 +1,22 @@
-"""Parameter transform registry shared across inference backends.
+"""Functions that map model parameters between the optimiser's scale and their natural scale.
 
-Every free parameter is optimized on an unconstrained scale and mapped into its
-support through this registry. The same transform metadata is reused by Python
-MLE code and Stan code generation.
+When fitting a model, numerical optimisers work most reliably with parameters
+that can take any real value (from -infinity to +infinity). But model parameters
+often have natural constraints — for example, a learning rate must lie between 0
+and 1, and an inverse temperature must be positive.
+
+This module provides a registry of mathematical transforms that convert between
+the two scales:
+
+- The *forward* direction takes a raw unconstrained number from the optimiser
+  and maps it onto the parameter's natural scale (e.g. squeezes a real number
+  into (0, 1) for a learning rate).
+- The *inverse* direction takes a value on the natural scale and maps it back
+  to an unconstrained number (needed to set starting values for the optimiser).
+
+The same transform definitions are used by both the Python fitting code and the
+Stan code generator, so both backends are guaranteed to use identical
+transformations.
 """
 
 from __future__ import annotations
@@ -24,44 +38,46 @@ _SOFTPLUS_STABLE_SWITCH = math.log(2.0)
 
 
 def _sigmoid(value: float) -> float:
-    """Map an unconstrained value to the unit interval.
+    """Squeeze any real number into the open interval (0, 1).
+
+    Used to transform learning rate parameters (alpha) from the optimiser's
+    unconstrained scale onto their natural scale. For example, an optimiser
+    value of 0 maps to 0.5; large positive values approach 1; large negative
+    values approach 0.
 
     Parameters
     ----------
     value
-        Unconstrained scalar.
+        Any real number (the optimiser's internal representation of the
+        parameter).
 
     Returns
     -------
     float
-        Sigmoid-transformed scalar in `(0, 1)`.
-
-    Notes
-    -----
-    SciPy's numerically stable logistic implementation is used so the forward
-    transform matches the inverse and Stan's ``inv_logit`` behavior closely.
+        The corresponding learning rate in (0, 1), never exactly 0 or 1.
     """
 
     return float(special.expit(value))
 
 
 def _inverse_sigmoid(value: float) -> float:
-    """Map a probability back to the real line.
+    """Convert a probability back to an unconstrained real number.
+
+    This is the reverse of ``_sigmoid``. Used to convert a human-readable
+    parameter value (e.g. a starting learning rate of 0.3) into the
+    unconstrained number that the optimiser expects as its starting point.
+    Values exactly at 0 or 1 are nudged slightly inward to keep the output
+    finite.
 
     Parameters
     ----------
     value
-        Probability in `(0, 1)`.
+        A probability in (0, 1), such as a learning rate.
 
     Returns
     -------
     float
-        Logit-transformed scalar.
-
-    Notes
-    -----
-    Inputs are clamped away from exactly ``0`` and ``1`` so restart generation
-    and inverse-round-trip tests stay finite at closed-domain boundaries.
+        The corresponding unconstrained real number.
     """
 
     clamped_value = min(max(value, _PROBABILITY_LOWER_BOUND), _PROBABILITY_UPPER_BOUND)
@@ -69,22 +85,23 @@ def _inverse_sigmoid(value: float) -> float:
 
 
 def _softplus(value: float) -> float:
-    """Map an unconstrained value to a positive scalar.
+    """Map any real number to a strictly positive value.
+
+    Used to transform the inverse temperature parameter (beta) from the
+    optimiser's unconstrained scale to its natural scale. The softplus function
+    is a smooth, always-positive alternative to simply exponentiating the value;
+    it grows linearly for large inputs (avoiding overflow) and approaches zero
+    for very negative inputs (but never reaches it).
 
     Parameters
     ----------
     value
-        Unconstrained scalar.
+        Any real number (the optimiser's internal representation of beta).
 
     Returns
     -------
     float
-        Positive softplus-transformed scalar.
-
-    Notes
-    -----
-    Large positive values bypass ``exp`` and return the input directly, matching
-    the asymptotic behavior of softplus while avoiding overflow.
+        A strictly positive number representing the inverse temperature.
     """
 
     if value > 20.0:
@@ -93,22 +110,22 @@ def _softplus(value: float) -> float:
 
 
 def _inverse_softplus(value: float) -> float:
-    """Map a positive scalar back to the real line.
+    """Convert a positive parameter value back to an unconstrained real number.
+
+    This is the reverse of ``_softplus``. Used to convert a human-readable
+    beta value (e.g. a starting inverse temperature of 2.0) into the
+    unconstrained number the optimiser expects. Values at or below zero are
+    clamped to a tiny positive number to keep the output finite.
 
     Parameters
     ----------
     value
-        Positive scalar.
+        A positive number, such as an inverse temperature value.
 
     Returns
     -------
     float
-        Inverse softplus-transformed scalar.
-
-    Notes
-    -----
-    Inputs are clamped above zero and evaluated with two stable branches so
-    extremely small or moderately large positive values both remain finite.
+        The corresponding unconstrained real number.
     """
 
     clamped_value = max(value, _POSITIVE_LOWER_BOUND)
@@ -119,21 +136,26 @@ def _inverse_softplus(value: float) -> float:
 
 @dataclass(frozen=True, slots=True)
 class Transform:
-    """Forward and inverse parameter transform metadata.
+    """A paired forward-and-inverse parameter transformation.
+
+    Bundles the two directions of a transformation together with the equivalent
+    Stan expression so that Python fitting code and Stan-based Bayesian fitting
+    always use the identical mathematical operation.
 
     Attributes
     ----------
     forward
-        Function mapping an unconstrained scalar to the constrained space.
+        Function that maps an unconstrained optimiser value to the parameter's
+        natural scale (e.g. real number to learning rate in (0, 1)).
     inverse
-        Function mapping a constrained scalar to the unconstrained space.
+        Function that maps a value on the natural scale back to the
+        unconstrained scale (e.g. learning rate to a real number). Used when
+        setting optimiser starting points from interpretable parameter values.
     stan_expression
-        Stan template string using `{x}` as the placeholder variable.
-
-    Notes
-    -----
-    ``stan_expression`` keeps the Stan backend tied to the same conceptual
-    transform as the Python backend without having Stan call back into Python.
+        The equivalent Stan code snippet, written as a template with ``{x}``
+        as a placeholder for the unconstrained variable name. Keeps the Stan
+        model consistent with the Python model without requiring Stan to call
+        back into Python.
     """
 
     forward: Callable[[float], float]
@@ -166,27 +188,37 @@ TRANSFORM_REGISTRY: dict[str, Transform] = {
 
 
 def get_transform(transform_id: str) -> Transform:
-    """Look up a named transform from the registry.
+    """Retrieve a named transform from the registry by its identifier.
+
+    Centralising lookups here means both the Python fitting code and the Stan
+    code generator always retrieve the same transform object, preventing the
+    two backends from silently diverging.
+
+    Available transforms:
+
+    - ``"sigmoid"``: maps any real number to (0, 1). Used for learning rates.
+    - ``"softplus"``: maps any real number to (0, +inf). Used for inverse
+      temperature (beta).
+    - ``"exp"``: maps any real number to (0, +inf) via exponentiation.
+    - ``"identity"``: no transformation — the parameter is already on the
+      correct scale.
 
     Parameters
     ----------
     transform_id
-        Identifier of the requested transform.
+        The short name of the desired transform (e.g. ``"sigmoid"``).
 
     Returns
     -------
     Transform
-        Registered transform metadata.
+        The corresponding ``Transform`` object with forward and inverse
+        functions and a Stan expression.
 
     Raises
     ------
     ValueError
-        Raised when the requested transform is not registered.
-
-    Notes
-    -----
-    All backends should resolve transforms through this function instead of
-    assuming hard-coded transform logic at individual call sites.
+        Raised with a helpful message when the requested name is not in the
+        registry.
     """
 
     if transform_id not in TRANSFORM_REGISTRY:

--- a/src/comp_model/runtime/engine.py
+++ b/src/comp_model/runtime/engine.py
@@ -1,8 +1,21 @@
-"""Simulation engine for generating event-based subject data.
+"""Engine for running artificial participants through a task and producing synthetic data.
 
-The runtime executes task structure and environment dynamics while delegating
-choice and learning to a model kernel. The resulting event traces are the same
-objects later consumed by validation, replay, and Stan export.
+This module is the bridge between a computational model and a task design.
+Given a model (kernel + parameters) and a task design (TaskSpec), it runs the
+model through each trial and records everything that happens — choices, rewards,
+learning updates — in exactly the same data format that real participant data
+uses.
+
+Why is this useful?
+- Parameter recovery: simulate data with known parameters, then fit the model
+  to the synthetic data to check that you can recover what you put in.
+- Posterior predictive checks: simulate data from fitted parameters and compare
+  the synthetic behaviour to what real participants did.
+- Pilot work: explore what your model predicts before collecting real data.
+
+The output is indistinguishable in format from real data, so all downstream
+analysis code (validation, model fitting, visualisation) works on it without
+modification.
 """
 
 from __future__ import annotations
@@ -29,17 +42,24 @@ ParamsT = TypeVar("ParamsT")
 
 @dataclass(frozen=True, slots=True)
 class SimulationConfig:
-    """Configuration for stochastic simulation runs.
+    """Settings that control how random choices are made during simulation.
 
     Attributes
     ----------
     seed
-        Optional random seed for the subject-level RNG.
+        An integer that pins the random-number generator to a specific
+        sequence, making results exactly reproducible. Set to ``None``
+        to use a different random sequence every time.
 
     Notes
     -----
-    Dataset simulation offsets this base seed by subject index so each simulated
-    subject receives an independent but reproducible random stream.
+    When simulating a whole group of participants (see
+    :func:`simulate_dataset`), each simulated participant gets their own
+    independent random stream. This is achieved by adding the participant's
+    position in the list (0, 1, 2, …) to the base seed. So if you set
+    ``seed=42``, participant 0 uses seed 42, participant 1 uses seed 43,
+    and so on. This keeps participants independent while keeping everything
+    reproducible.
     """
 
     seed: int | None = None
@@ -56,59 +76,82 @@ def simulate_subject(
     config: SimulationConfig,
     subject_id: str = "sim_subject",
 ) -> SubjectData:
-    """Simulate a single subject through an entire task.
+    """Run one artificial participant through the entire task and record what happened.
+
+    This function is the core simulation loop. It walks through every block and
+    every trial, asking the model (``kernel``) what the participant would do,
+    asking the task environment what reward they would receive, and recording
+    everything as a structured event log.
+
+    The result looks identical to real participant data: a log of choices,
+    rewards, and learning updates, organised by block and trial.
 
     Parameters
     ----------
     task
-        Task specification to execute.
+        The experimental design — which blocks exist, how many trials each
+        contains, and in what order events unfold within each trial.
     env
-        Environment instance for the task.
+        The task environment that hands out rewards when the participant
+        makes a choice (analogous to the slot machines or stimuli in the
+        real experiment).
     kernel
-        Model kernel for the subject.
+        The computational model that decides how the participant chooses
+        and learns. Think of it as the "brain" of the artificial participant.
     params
-        Parsed subject kernel parameters.
+        The specific parameter values for this participant (e.g. their
+        learning rate, inverse temperature).
     demonstrator_kernel
-        Optional kernel for the demonstrator agent.
+        If the task includes a second agent (a demonstrator) whose choices
+        the participant can observe, supply that agent's model here.
     demonstrator_params
-        Parsed demonstrator kernel parameters. Required when
+        Parameter values for the demonstrator. Required when
         ``demonstrator_kernel`` is provided.
     config
-        Simulation configuration.
+        Controls the random seed so simulations are reproducible.
     subject_id
-        Identifier assigned to the simulated subject.
+        A name or identifier attached to the simulated participant's data.
 
     Returns
     -------
     SubjectData
-        Simulated hierarchical event trace for one subject.
+        The full event log for one simulated participant, structured
+        identically to real participant data.
 
     Notes
     -----
-    The simulation loop steps through the schema position by position, constructing
-    events and updating agent states in a single pass. At each DECISION step the
-    relevant agent's kernel supplies action probabilities. At each OUTCOME step
-    the environment is queried for a reward. At each UPDATE step the learner's
-    state is advanced immediately, so updates fire at their declared schema
-    positions (e.g. a social update before the subject's own decision in
-    pre-choice schemas).
+    The loop processes each trial in a single pass through the trial schema
+    (the sequence of events defined for that block). Events are constructed
+    and the model's internal state is updated in the same pass, one schema
+    step at a time. This matters for social-learning tasks: if the schema
+    says the demonstrator's learning update happens *before* the participant
+    decides, that ordering is respected exactly.
     """
 
     rng = np.random.default_rng(config.seed)
     blocks: list[Block] = []
 
     n_actions = _infer_n_actions_from_task(task)
+
+    # Give every agent a blank starting state (e.g. all Q-values set to their
+    # initial values, no experience accumulated yet).
     states: dict[str, object] = {"subject": kernel.initial_state(n_actions, params)}
     if demonstrator_kernel is not None and demonstrator_params is not None:
         states["demonstrator"] = demonstrator_kernel.initial_state(n_actions, demonstrator_params)
 
+    # Find out whether this model forgets everything between blocks or carries
+    # its learned values from one block into the next.
     reset_policy = kernel.spec().state_reset_policy
 
     for block_index, block_spec in enumerate(task.blocks):
+        # Prepare the reward environment for this block (e.g. set new reward
+        # probabilities if they change between blocks).
         env.reset(block_spec, rng=rng)
         schema = block_spec.schema
         available_actions = tuple(range(int(block_spec.metadata["n_actions"])))
 
+        # If the model is configured to reset between blocks, wipe its learned
+        # state at the start of every block after the first.
         if reset_policy == "per_block" and block_index > 0:
             states["subject"] = kernel.initial_state(n_actions, params)
             if demonstrator_kernel is not None and demonstrator_params is not None:
@@ -123,8 +166,15 @@ def simulate_subject(
             rewards: dict[str, float] = {}
             trial_events: list[Event] = []
 
+            # Walk through the schema step-by-step. The schema defines the
+            # order of events in each trial (e.g. INPUT → DECISION → OUTCOME →
+            # UPDATE). We construct each event and, where needed, update the
+            # model's internal state, all in this single pass.
             for event_index, step in enumerate(schema.steps):
                 if step.phase == EventPhase.INPUT:
+                    # Record which actions were available at the start of this
+                    # trial. No model update is needed here; this is purely
+                    # bookkeeping so the data log is complete.
                     trial_events.append(
                         Event(
                             phase=EventPhase.INPUT,
@@ -141,6 +191,9 @@ def simulate_subject(
                         trial_index=trial_index,
                         available_actions=available_actions,
                     )
+                    # Ask the relevant agent's model for a probability over
+                    # each available action, then randomly sample one action
+                    # according to those probabilities (softmax sampling).
                     if actor == "subject":
                         probabilities = kernel.action_probabilities(
                             cast("StateT", states["subject"]), view, params
@@ -170,6 +223,8 @@ def simulate_subject(
                     )
 
                 elif step.phase == EventPhase.OUTCOME:
+                    # Ask the environment what reward the actor receives for
+                    # the choice they just made, then record it.
                     actor = step.actor_id
                     reward = env.step(choices[actor])
                     rewards[actor] = reward
@@ -186,6 +241,9 @@ def simulate_subject(
                 elif step.phase == EventPhase.UPDATE:
                     actor = step.actor_id
                     learner = step.learner_id
+
+                    # First, record the update event (what choice was made and
+                    # what reward was received — the information being learned from).
                     trial_events.append(
                         Event(
                             phase=EventPhase.UPDATE,
@@ -196,7 +254,14 @@ def simulate_subject(
                         )
                     )
 
+                    # Then immediately call next_state to advance the learner's
+                    # internal state (e.g. update Q-values). Doing this here,
+                    # inside the schema loop, means the update fires at exactly
+                    # the position the schema declares — crucially, a social
+                    # update can happen *before* the subject's own decision in
+                    # pre-choice schemas.
                     if actor == learner:
+                        # The learner is updating from their *own* experience.
                         view = DecisionTrialView(
                             trial_index=trial_index,
                             available_actions=available_actions,
@@ -204,6 +269,9 @@ def simulate_subject(
                             reward=rewards[actor],
                         )
                     else:
+                        # The learner is updating from *someone else's* experience
+                        # (social learning). Only include the fields that the schema
+                        # says are visible to the observer.
                         obs = step.observable_fields
                         view = DecisionTrialView(
                             trial_index=trial_index,
@@ -247,36 +315,41 @@ def simulate_dataset(
     demonstrator_kernel: ModelKernel[object, object] | None = None,
     demonstrator_params: object | None = None,
 ) -> Dataset:
-    """Simulate a dataset for multiple subjects.
+    """Simulate a whole group of artificial participants and return the combined dataset.
+
+    Calls :func:`simulate_subject` once per participant, giving each one a
+    fresh, independent copy of the task environment and a unique random seed
+    derived from ``config.seed``. The result is a dataset that can be used
+    for parameter recovery or posterior predictive checks on a full sample.
 
     Parameters
     ----------
     task
-        Task specification to execute.
+        The experimental design shared by all participants.
     env_factory
-        Factory returning a fresh environment per subject.
+        A function that creates a fresh environment instance. Called once
+        per participant so that each participant starts with independent
+        environment state (e.g. independent reward draws).
     kernel
-        Model kernel used to choose and update.
+        The computational model (learning and choice rule) applied to every
+        participant.
     params_per_subject
-        Parsed kernel parameters keyed by subject identifier.
+        A mapping from participant identifier to that participant's
+        parameter values. The order of entries determines simulation order.
     config
-        Simulation configuration shared across subjects.
+        Shared simulation settings, including the base random seed.
     demonstrator_kernel
-        Optional kernel for the demonstrator agent.
+        If the task involves a demonstrator agent, supply their model here.
+        The same demonstrator model is used for every participant.
     demonstrator_params
-        Parsed demonstrator kernel parameters. Required when
+        Parameter values for the demonstrator. Required when
         ``demonstrator_kernel`` is provided.
 
     Returns
     -------
     Dataset
-        Simulated dataset across all requested subjects.
-
-    Notes
-    -----
-    Subjects are simulated independently with fresh environments returned by
-    ``env_factory``. Subject order follows the insertion order of
-    ``params_per_subject``.
+        Simulated data for all participants, in the same order as
+        ``params_per_subject``.
     """
 
     subjects: list[SubjectData] = []
@@ -301,28 +374,34 @@ def simulate_dataset(
 
 
 def _infer_n_actions_from_task(task: TaskSpec) -> int:
-    """Infer the number of actions from task metadata.
+    """Read the number of response options from the task design.
+
+    The model needs to know how many actions exist (e.g. two slot machines,
+    three stimuli) before the task begins, so that it can initialise the right
+    number of Q-values. This function reads that number from the block
+    metadata rather than hard-coding it, keeping the engine general.
 
     Parameters
     ----------
     task
-        Task specification whose block metadata are inspected.
+        The task design whose block metadata are inspected.
 
     Returns
     -------
     int
-        Unique action count specified across blocks.
+        The number of available actions, which must be the same in every block.
 
     Raises
     ------
     ValueError
-        Raised when action counts are missing or inconsistent.
+        Raised when the action count is missing from block metadata, or when
+        different blocks disagree on how many actions exist.
 
     Notes
     -----
-    The runtime currently relies on ``BlockSpec.metadata['n_actions']`` rather
-    than inferring action count from a model or environment. All blocks must
-    agree on the same action count.
+    Every ``BlockSpec`` in the task must have ``metadata['n_actions']`` set,
+    and all blocks must report the same value. Mismatches suggest a design
+    error in the task specification.
     """
 
     n_actions_values: set[int] = set()

--- a/src/comp_model/tasks/schemas.py
+++ b/src/comp_model/tasks/schemas.py
@@ -1,8 +1,23 @@
-"""Declarative event-order schemas for trial structure.
+"""Trial schemas — scripts that define the event order within a single trial.
 
-Trial schemas are the positional source of truth for trial semantics. The same
-schema definition is shared by environments, validators, and extractors so that
-simulation and replay operate on the same event-order contract.
+A schema is a precise description of what happens in a trial: which events
+occur, in what order, who is the actor for each event (subject or
+demonstrator), and what information is available to the learner at each step.
+
+Schemas serve three purposes, all using the same definition:
+
+1. Driving simulation: the environment reads the schema step by step to know
+   what event type to generate next.
+2. Validating recorded data: when loading real experimental data, each trial
+   is checked against the schema to confirm that events appear in the correct
+   order with the correct actors.
+3. Guiding data extraction: the schema tells the data extractor how to
+   interpret each event — for example, which events carry the subject's own
+   choice versus the demonstrator's observable outcome.
+
+Pre-built schemas for common experimental designs are provided at the bottom of
+this module. Choose the schema that matches your experimental protocol and pass
+it to the environment or fitting pipeline.
 """
 
 from __future__ import annotations
@@ -15,29 +30,36 @@ from comp_model.data.validation import validate_event_payload
 
 @dataclass(frozen=True, slots=True)
 class TrialSchemaStep:
-    """Single positional step inside a declarative trial schema.
+    """One event slot in a trial script.
+
+    Each step describes a single event that should occur at that position in
+    the trial. Steps are matched positionally — the first step describes the
+    first event, the second step describes the second event, and so on.
 
     Attributes
     ----------
     phase
-        Phase expected at this step.
+        The type of event expected at this position. Common phases are INPUT
+        (options become available), DECISION (a choice is recorded), OUTCOME
+        (a reward is delivered), and UPDATE (beliefs are updated).
     node_id
-        Decision-point identifier expected at this step.
+        The name of the decision point this event belongs to. Used to match
+        recorded events to the correct position in the schema.
     actor_id
-        Actor expected at this step.
+        Who performs the action at this step — either ``"subject"`` (the
+        participant) or ``"demonstrator"``. Defaults to ``"subject"``.
     learner_id
-        Whose kernel state is updated at this step. Only meaningful on UPDATE
-        steps. Defaults to ``"subject"``.
+        Whose internal model is updated at this step. Relevant only for UPDATE
+        steps. Defaults to ``"subject"``. For social learning steps the
+        ``learner_id`` and ``actor_id`` differ: the actor is the demonstrator
+        but the learner is the subject.
     observable_fields
-        For social UPDATE steps (``actor_id != learner_id``): which fields from
-        the actor's trial are visible to the learner. Must be non-empty on
-        social UPDATE steps. Valid values: ``"action"``, ``"reward"``.
-
-    Notes
-    -----
-    ``node_id`` and ``actor_id`` are matching constraints, not semantic dispatch
-    keys. Extraction logic stays schema-driven and positional instead of
-    branching on arbitrary node-name strings.
+        For UPDATE steps where the learner is watching the actor (i.e.
+        ``actor_id`` and ``learner_id`` differ): which pieces of the actor's
+        outcome are visible to the learner. Must be specified for every such
+        social update step. Allowed values are ``"action"`` (the demonstrator's
+        choice is visible) and ``"reward"`` (the demonstrator's reward is
+        visible). Omitting ``"reward"`` models action-only social observation.
     """
 
     phase: EventPhase
@@ -49,22 +71,24 @@ class TrialSchemaStep:
 
 @dataclass(frozen=True, slots=True)
 class TrialSchema:
-    """Valid event ordering for one trial type.
+    """A complete script for one type of trial.
+
+    A ``TrialSchema`` is an ordered list of steps (``TrialSchemaStep``) that
+    describes everything that should happen in a trial of this type: which
+    events occur, in what order, and who acts or learns at each step.
+
+    The same schema object drives simulation, validates recorded data, and
+    guides feature extraction — there is a single source of truth for the
+    trial structure.
 
     Attributes
     ----------
     schema_id
-        Stable identifier for the schema.
+        A short, stable name for this schema (e.g. ``"asocial_bandit"``). Used
+        for logging and error messages.
     steps
-        Ordered schema steps that each trial must match positionally.
-
-    Notes
-    -----
-    ``TrialSchema`` does three jobs with the same positional contract:
-
-    1. it tells environments what event type should occur next,
-    2. it validates recorded trials, and
-    3. it tells the extractor how to interpret events around each decision.
+        The ordered list of event slots that every trial of this type must
+        match, position by position.
     """
 
     schema_id: str
@@ -84,23 +108,29 @@ class TrialSchema:
                 )
 
     def validate_trial(self, trial: Trial) -> None:
-        """Validate a trial against the schema definition.
+        """Check that a recorded trial matches this schema exactly.
+
+        Compares the trial's events against the schema step by step. If
+        anything does not match — wrong number of events, wrong event type,
+        wrong actor, wrong position — a descriptive error is raised so you can
+        identify the problematic trial and step.
 
         Parameters
         ----------
         trial
-            Trial to validate.
+            A single recorded trial to check.
 
         Returns
         -------
         None
-            This function raises on any mismatch.
+            Returns silently if the trial is valid.
 
         Raises
         ------
         ValueError
-            Raised when event count, phase, ``node_id``, ``actor_id``, event
-            index, or required payload keys differ from the schema contract.
+            Raised with a descriptive message when the trial does not conform
+            to the schema (e.g. wrong number of events, unexpected actor,
+            mismatched event type, or missing required data fields).
         """
 
         if len(trial.events) != len(self.steps):
@@ -134,12 +164,17 @@ class TrialSchema:
 
     @property
     def decision_step_indices(self) -> tuple[int, ...]:
-        """Indices of all decision steps in the schema.
+        """The positions (0-based) in the trial where a choice is made.
+
+        A trial may contain more than one decision step — for example, in
+        social designs both the demonstrator and the subject make a choice.
+        This property returns the indices of all such steps so that downstream
+        code can locate choices without needing to know the schema structure.
 
         Returns
         -------
         tuple[int, ...]
-            Positions whose phase is :class:`~comp_model.data.schema.EventPhase.DECISION`.
+            Zero-based indices of all DECISION steps in the schema, in order.
         """
 
         return tuple(
@@ -147,6 +182,9 @@ class TrialSchema:
         )
 
 
+# Standard solo learning trial.
+# Trial order: options appear → subject chooses → subject receives reward → beliefs updated.
+# No demonstrator is present. Use this for basic multi-armed bandit experiments.
 ASOCIAL_BANDIT_SCHEMA = TrialSchema(
     schema_id="asocial_bandit",
     steps=(
@@ -157,6 +195,12 @@ ASOCIAL_BANDIT_SCHEMA = TrialSchema(
     ),
 )
 
+# Demonstrator-first social learning trial (subject sees choice AND reward before acting).
+# Trial order: demonstrator sees options → demonstrator chooses → demonstrator gets reward →
+#   demonstrator's beliefs updated → subject observes demo's choice+reward and updates →
+#   subject sees options → subject chooses → subject gets reward → subject's beliefs updated.
+# Use this when participants watch the demonstrator's full outcome before making their own choice.
+# Social learning can therefore influence the current trial's choice.
 SOCIAL_PRE_CHOICE_SCHEMA = TrialSchema(
     schema_id="social_pre_choice",
     steps=(
@@ -180,6 +224,10 @@ SOCIAL_PRE_CHOICE_SCHEMA = TrialSchema(
     ),
 )
 
+# Demonstrator-first social learning trial (subject sees choice ONLY, not reward, before acting).
+# Identical structure to SOCIAL_PRE_CHOICE_SCHEMA except that when the subject observes the
+# demonstrator, only the demonstrator's choice is visible — the reward is hidden.
+# Use this to model action imitation without outcome knowledge.
 SOCIAL_PRE_CHOICE_ACTION_ONLY_SCHEMA = TrialSchema(
     schema_id="social_pre_choice_action_only",
     steps=(
@@ -203,6 +251,13 @@ SOCIAL_PRE_CHOICE_ACTION_ONLY_SCHEMA = TrialSchema(
     ),
 )
 
+# Subject-first social learning trial (subject acts, then watches demonstrator's choice+reward).
+# Trial order: subject sees options → subject chooses → subject gets reward →
+#   subject's beliefs updated → demonstrator sees options → demonstrator chooses →
+#   demonstrator gets reward → demonstrator's beliefs updated →
+#   subject observes demo's choice+reward and updates.
+# Because the demonstrator is observed after the subject has already chosen, the social
+# information can only influence future trials, not the current one.
 SOCIAL_POST_OUTCOME_SCHEMA = TrialSchema(
     schema_id="social_post_outcome",
     steps=(
@@ -226,6 +281,9 @@ SOCIAL_POST_OUTCOME_SCHEMA = TrialSchema(
     ),
 )
 
+# Subject-first social learning trial (subject acts, then watches demonstrator's choice ONLY).
+# Identical structure to SOCIAL_POST_OUTCOME_SCHEMA except that the subject only sees the
+# demonstrator's choice, not the reward. Social learning therefore carries no outcome signal.
 SOCIAL_POST_OUTCOME_ACTION_ONLY_SCHEMA = TrialSchema(
     schema_id="social_post_outcome_action_only",
     steps=(
@@ -249,10 +307,14 @@ SOCIAL_POST_OUTCOME_ACTION_ONLY_SCHEMA = TrialSchema(
     ),
 )
 
-# Schemas where the subject's own outcome is not observable.  The subject acts
-# but receives no feedback — the trial has no subject OUTCOME or subject
-# self-UPDATE event.  Only demonstrator information drives learning.
+# Schemas where the subject acts but receives no feedback on their own outcome.
+# The subject makes a choice but is never told whether it was rewarded.
+# Only the demonstrator's outcome can drive learning in these designs.
 
+# Demonstrator-first, no self-feedback trial.
+# Trial order: demonstrator acts and gets reward → subject observes demo's choice+reward →
+#   subject chooses (but receives no reward and gets no personal update).
+# Use this to isolate pure social learning: only the demonstrator's outcome can shape beliefs.
 SOCIAL_PRE_CHOICE_NO_SELF_OUTCOME_SCHEMA = TrialSchema(
     schema_id="social_pre_choice_no_self_outcome",
     steps=(
@@ -274,6 +336,11 @@ SOCIAL_PRE_CHOICE_NO_SELF_OUTCOME_SCHEMA = TrialSchema(
     ),
 )
 
+# Subject-first, no self-feedback trial.
+# Trial order: subject chooses (no reward given) → demonstrator acts and gets reward →
+#   subject observes demo's choice+reward and updates.
+# Use this when you want the subject to commit to a choice before seeing the demo,
+# but still learn only from the demonstrator's outcome (no personal feedback).
 SOCIAL_POST_OUTCOME_NO_SELF_OUTCOME_SCHEMA = TrialSchema(
     schema_id="social_post_outcome_no_self_outcome",
     steps=(
@@ -295,10 +362,17 @@ SOCIAL_POST_OUTCOME_NO_SELF_OUTCOME_SCHEMA = TrialSchema(
     ),
 )
 
-# Schemas where the demonstrator also updates from the subject's action and
-# reward.  The social UPDATE step carries the observed actor's choice and reward
-# in its event payload, as populated by the simulation engine or CSV loader.
+# Bidirectional social learning schemas — both the subject and the demonstrator
+# learn from each other's outcomes.
+# In these designs the demonstrator also observes the subject's choice and reward
+# and updates their own beliefs accordingly. This models dyadic or reciprocal
+# social learning where influence flows in both directions.
 
+# Demonstrator-first, bidirectional learning trial.
+# Trial order: demonstrator acts+gets reward → subject observes demo (choice+reward) →
+#   subject acts+gets reward → demonstrator observes subject (choice+reward).
+# Both agents learn from each other. The subject still observes the demonstrator before
+# choosing, so social information can influence the current trial's choice.
 SOCIAL_PRE_CHOICE_DEMO_LEARNS_SCHEMA = TrialSchema(
     schema_id="social_pre_choice_demo_learns",
     steps=(
@@ -329,6 +403,11 @@ SOCIAL_PRE_CHOICE_DEMO_LEARNS_SCHEMA = TrialSchema(
     ),
 )
 
+# Subject-first, bidirectional learning trial.
+# Trial order: subject acts+gets reward → demonstrator observes subject (choice+reward) →
+#   demonstrator acts+gets reward → subject observes demo (choice+reward).
+# Both agents learn from each other. Because the subject acts before watching the demo,
+# social information from this trial can only shape future choices.
 SOCIAL_POST_OUTCOME_DEMO_LEARNS_SCHEMA = TrialSchema(
     schema_id="social_post_outcome_demo_learns",
     steps=(

--- a/src/comp_model/tasks/spec.py
+++ b/src/comp_model/tasks/spec.py
@@ -1,8 +1,25 @@
-"""Task-level design specifications.
+"""Descriptions of the experimental design, independent of models and fitting.
 
-Task objects describe experimental structure independently of any agent or
-inference backend. They own block order, condition labels, trial counts,
-schemas, and task metadata consumed by environments.
+This module is the "experiment design" layer. It lets you describe what
+participants did — which blocks existed, how many trials each block contained,
+in what order events unfolded within each trial, and what the reward
+contingencies were — without saying anything about how participants behaved
+or how models were fitted to their data.
+
+Two classes carry this information:
+
+- :class:`BlockSpec`: one block of the experiment.
+- :class:`TaskSpec`: the full task as an ordered sequence of blocks.
+
+Why keep design separate from models and fitting?
+The same task design object can be reused with many different models and
+fitting backends. Conversely, the same model can be applied to tasks with
+different designs. Keeping them separate avoids accidental coupling and
+makes it easy to swap components independently.
+
+Note: computational models (kernels) never read ``BlockSpec`` or ``TaskSpec``
+directly. They only ever see compact summaries of individual decision trials
+(``DecisionTrialView`` objects produced during simulation or data replay).
 """
 
 from __future__ import annotations
@@ -20,24 +37,32 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, slots=True)
 class BlockSpec:
-    """Design metadata for one task block.
+    """The design specification for one block of the task.
+
+    A block is a run of consecutive trials that share the same condition and
+    the same within-trial event structure (schema). For example, in a
+    two-phase bandit task you might have a "social observation" block followed
+    by an "individual choice" block — each would be a separate ``BlockSpec``.
 
     Attributes
     ----------
     condition
-        Condition label for the block.
+        A label identifying the experimental condition for this block
+        (e.g. ``"social"``, ``"individual"``, ``"test"``). Used to group
+        and compare blocks in analysis.
     n_trials
-        Number of trials to run in the block.
+        How many trials this block contains.
     schema
-        Trial schema executed by the environment.
+        The within-trial event sequence for this block — for example:
+        INPUT → (demonstrator) DECISION → (demonstrator) OUTCOME →
+        (demonstrator) UPDATE → (subject) DECISION → …
+        See :class:`~comp_model.tasks.schemas.TrialSchema`.
     metadata
-        Optional block-level task metadata.
-
-    Notes
-    -----
-    Environments read ``metadata`` to configure block-specific dynamics such as
-    action count or reward contingencies. Kernels do not read ``BlockSpec``
-    directly.
+        A flexible dictionary for any extra block-level information the
+        task environment needs, such as reward probabilities
+        (``"reward_probs"``) or the number of available actions
+        (``"n_actions"``). Computational models never read this directly;
+        only the task environment uses it.
     """
 
     condition: str
@@ -48,20 +73,27 @@ class BlockSpec:
 
 @dataclass(frozen=True, slots=True)
 class TaskSpec:
-    """Immutable specification of a full task design.
+    """The complete experimental design: an ordered sequence of blocks.
+
+    A ``TaskSpec`` is the top-level description of an entire task. It lists
+    all blocks in the order they are presented to participants, and nothing
+    more. It does not say anything about how participants behave (that is the
+    kernel's job) or how models are fitted to data (that is the inference
+    backend's job).
+
+    The simulation engine (:func:`~comp_model.runtime.engine.simulate_subject`)
+    reads this object to know what to simulate. Fitted models never read it
+    directly — they only ever see the compact decision-trial summaries that the
+    engine produces.
 
     Attributes
     ----------
     task_id
-        Stable task identifier.
+        A stable name or identifier for the task (e.g. ``"two_armed_bandit"``).
+        Used as a label in output files and logs.
     blocks
-        Ordered block specifications for the task.
-
-    Notes
-    -----
-    ``TaskSpec`` is the structural design layer. The runtime executes it, while
-    fitted models only ever see extracted decision views derived from the event
-    traces it generates.
+        The blocks of the task in presentation order. Each element is a
+        :class:`BlockSpec` describing that block's design.
     """
 
     task_id: str
@@ -69,25 +101,28 @@ class TaskSpec:
 
     @property
     def n_blocks(self) -> int:
-        """Return the number of blocks in the task.
+        """Return how many blocks the task contains.
 
         Returns
         -------
         int
-            Number of block specifications in execution order.
+            The total number of blocks, in the order they are presented.
         """
 
         return len(self.blocks)
 
     @property
     def conditions(self) -> tuple[str, ...]:
-        """Return condition labels in first-seen order without duplicates.
+        """Return the unique condition labels in the order they first appear.
+
+        Useful for iterating over conditions without repeating yourself
+        when the same condition label appears in multiple blocks.
 
         Returns
         -------
         tuple[str, ...]
-            Ordered unique condition labels, preserving the first occurrence of
-            each condition in ``blocks``.
+            Each unique condition label exactly once, ordered by first
+            occurrence across ``blocks``.
         """
 
         seen: set[str] = set()


### PR DESCRIPTION
## Summary

- Rewrites all module, class, and method docstrings across 10 core source files to be accessible to cognitive scientists and psychologists who are not software engineers
- Adds plain-English inline comments to the simulation engine and extractor explaining the *why* of each step
- No code changes — docstrings and comments only, all 139 tests pass

## Files changed

| File | What changed |
|---|---|
| `data/schema.py` | Event->Trial->Block hierarchy explained with plain analogies; EventPhase stages described as a decision cycle |
| `data/extractors.py` | Extraction pipeline explained; DecisionTrialView described as a "clean summary"; inline comments in `replay_trial_steps` |
| `runtime/engine.py` | `simulate_subject` described as running an artificial participant; inline comments throughout the single-pass loop |
| `models/kernels/base.py` | Kernel framed as answering 3 questions; parameter transforms explained plainly |
| `models/kernels/asocial_q_learning.py` | Q-values, Rescorla-Wagner update, and softmax rule in plain English |
| `models/kernels/social_rl_self_reward_demo_reward.py` | Two independent learning channels (self vs. social) explained with update equations |
| `models/kernels/probabilities.py` | Softmax and numerical stability explained for non-programmers |
| `models/kernels/transforms.py` | Constrained vs. unconstrained parameter scales explained |
| `tasks/schemas.py` | Each pre-built schema gets a comment describing the trial flow in words |
| `tasks/spec.py` | Design-layer separation from kernels and fitting backends explained |

## Test plan

- [x] 139 tests pass locally before and after changes
- [x] Linting passes (ruff, pyright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)