### PR TITLE
refactor(kernels): rename next_state → update on ModelKernel protocol

### DIFF
--- a/src/comp_model/inference/mle/objective.py
+++ b/src/comp_model/inference/mle/objective.py
@@ -68,7 +68,7 @@ def log_likelihood_simple(
                     choice_index = view.available_actions.index(view.choice)
                     total_log_likelihood += math.log(max(probabilities[choice_index], 1e-15))
                 elif event_type == EventPhase.UPDATE and learner_id == "subject":
-                    state = kernel.next_state(state, view, params)
+                    state = kernel.update(state, view, params)
 
     return total_log_likelihood
 
@@ -160,6 +160,6 @@ def log_likelihood_conditioned(
                     choice_index = view.available_actions.index(view.choice)
                     total_log_likelihood += math.log(max(probabilities[choice_index], 1e-15))
                 elif event_type == EventPhase.UPDATE and learner_id == "subject":
-                    state = kernel.next_state(state, view, condition_params)
+                    state = kernel.update(state, view, condition_params)
 
     return total_log_likelihood

--- a/src/comp_model/models/kernels/asocial_q_learning.py
+++ b/src/comp_model/models/kernels/asocial_q_learning.py
@@ -147,7 +147,7 @@ class AsocialQLearningKernel:
         -------
         QParams
             Parameter object with alpha and beta on their natural scales,
-            ready for use in ``action_probabilities`` and ``next_state``.
+            ready for use in ``action_probabilities`` and ``update``.
         """
 
         return QParams(
@@ -216,7 +216,7 @@ class AsocialQLearningKernel:
         logits = [params.beta * state.q_values[action] for action in view.available_actions]
         return stable_softmax(logits)
 
-    def next_state(
+    def update(
         self,
         state: QState,
         view: DecisionTrialView,

--- a/src/comp_model/models/kernels/asocial_rl_asymmetric.py
+++ b/src/comp_model/models/kernels/asocial_rl_asymmetric.py
@@ -190,7 +190,7 @@ class AsocialRlAsymmetricKernel:
         logits = [params.beta * state.q_values[action] for action in view.available_actions]
         return stable_softmax(logits)
 
-    def next_state(
+    def update(
         self,
         state: AsocialRlAsymmetricState,
         view: DecisionTrialView,

--- a/src/comp_model/models/kernels/base.py
+++ b/src/comp_model/models/kernels/base.py
@@ -186,7 +186,7 @@ class ModelKernel(Protocol, Generic[StateT, ParamsT]):
     1. :meth:`initial_state` — what is the participant's starting state?
     2. :meth:`action_probabilities` — given the current state, how likely is
        each action?
-    3. :meth:`next_state` — given the outcome, what is the updated state?
+    3. :meth:`update` — given the outcome, what is the updated state?
 
     Two additional methods are needed by the fitting and simulation machinery:
 
@@ -235,7 +235,7 @@ class ModelKernel(Protocol, Generic[StateT, ParamsT]):
         ParamsT
             A typed parameter object ready to be passed to
             :meth:`initial_state`, :meth:`action_probabilities`, and
-            :meth:`next_state`.
+            :meth:`update`.
         """
 
         ...
@@ -298,7 +298,7 @@ class ModelKernel(Protocol, Generic[StateT, ParamsT]):
 
         ...
 
-    def next_state(
+    def update(
         self,
         state: StateT,
         view: DecisionTrialView,

--- a/src/comp_model/models/kernels/social_rl_self_reward_demo_reward.py
+++ b/src/comp_model/models/kernels/social_rl_self_reward_demo_reward.py
@@ -228,7 +228,7 @@ class SocialRlSelfRewardDemoRewardKernel:
         logits = [params.beta * state.q_values[action] for action in view.available_actions]
         return stable_softmax(logits)
 
-    def next_state(
+    def update(
         self,
         state: SocialRlSelfRewardDemoRewardState,
         view: DecisionTrialView,

--- a/src/comp_model/runtime/engine.py
+++ b/src/comp_model/runtime/engine.py
@@ -254,7 +254,7 @@ def simulate_subject(
                         )
                     )
 
-                    # Then immediately call next_state to advance the learner's
+                    # Then immediately call update to advance the learner's
                     # internal state (e.g. update Q-values). Doing this here,
                     # inside the schema loop, means the update fires at exactly
                     # the position the schema declares — crucially, a social
@@ -283,11 +283,11 @@ def simulate_subject(
                         )
 
                     if learner == "subject":
-                        states["subject"] = kernel.next_state(
+                        states["subject"] = kernel.update(
                             cast("StateT", states["subject"]), view, params
                         )
                     elif demonstrator_kernel is not None and demonstrator_params is not None:
-                        states["demonstrator"] = demonstrator_kernel.next_state(
+                        states["demonstrator"] = demonstrator_kernel.update(
                             states["demonstrator"], view, demonstrator_params
                         )
 

--- a/tests/test_inference/test_social_stan_parity.py
+++ b/tests/test_inference/test_social_stan_parity.py
@@ -182,7 +182,7 @@ def _python_social_log_likelihoods(
                     choice_index = view.choice
                     trial_log_likelihood += float(np.log(probabilities[choice_index]))
                 elif event_type == "update" and learner_id == "subject":
-                    state = kernel.next_state(state, view, params)
+                    state = kernel.update(state, view, params)
             trial_log_likelihoods.append(trial_log_likelihood)
 
     return trial_log_likelihoods

--- a/tests/test_inference/test_stan_parity.py
+++ b/tests/test_inference/test_stan_parity.py
@@ -224,7 +224,7 @@ def _python_trial_log_likelihoods(subject: SubjectData, alpha: float, beta: floa
                     choice_index = view.choice
                     trial_log_likelihood += float(np.log(probabilities[choice_index]))
                 elif event_type == "update" and learner_id == "subject":
-                    state = kernel.next_state(state, view, params)
+                    state = kernel.update(state, view, params)
             trial_log_likelihoods.append(trial_log_likelihood)
 
     return trial_log_likelihoods

--- a/tests/test_models/test_asocial_q_learning.py
+++ b/tests/test_models/test_asocial_q_learning.py
@@ -45,7 +45,7 @@ def test_asocial_kernel_updates_chosen_q_value() -> None:
         reward=1.0,
     )
 
-    next_state = kernel.next_state(state, view, params)
+    updated_state = kernel.update(state, view, params)
 
-    assert next_state.q_values[0] == 0.5
-    assert next_state.q_values[1] > 0.5
+    assert updated_state.q_values[0] == 0.5
+    assert updated_state.q_values[1] > 0.5

--- a/tests/test_models/test_social_rl_self_reward_demo_reward.py
+++ b/tests/test_models/test_social_rl_self_reward_demo_reward.py
@@ -39,7 +39,7 @@ def test_social_kernel_updates_self_and_social_q_values() -> None:
         social_reward=0.0,
     )
 
-    next_state = kernel.next_state(state, view, params)
+    updated_state = kernel.update(state, view, params)
 
-    assert next_state.q_values[0] > 0.5
-    assert next_state.q_values[1] < 0.5
+    assert updated_state.q_values[0] > 0.5
+    assert updated_state.q_values[1] < 0.5


### PR DESCRIPTION
## Summary

- `next_state` was ambiguous — environments also have state, so the name didn't distinguish a world-state transition from an agent belief-update
- Renamed to `update` across the full codebase: protocol definition, all three kernel implementations, the MLE objective, the simulation engine, parity tests, and unit tests
- Local variable `next_state` in tests renamed to `updated_state` for consistency

## Test plan

- [ ] All 139 tests pass (`uv run pytest -x -q`)
- [ ] Pre-commit hooks pass (ruff, ruff-format, pyright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)