### PR TITLE
refactor(kernels): replace Protocol with ABC on ModelKernel

### DIFF
--- a/src/comp_model/models/kernels/asocial_q_learning.py
+++ b/src/comp_model/models/kernels/asocial_q_learning.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from comp_model.models.kernels.base import InitSpec, ModelKernelSpec, ParameterSpec
+from comp_model.models.kernels.base import InitSpec, ModelKernel, ModelKernelSpec, ParameterSpec
 from comp_model.models.kernels.probabilities import stable_softmax
 from comp_model.models.kernels.transforms import get_transform
 
@@ -74,7 +74,7 @@ class QState:
     q_values: list[float]
 
 
-class AsocialQLearningKernel:
+class AsocialQLearningKernel(ModelKernel[QState, QParams]):
     """Q-learning model for a participant who learns only from their own experience.
 
     This is the standard asocial reinforcement learning model. The agent

--- a/src/comp_model/models/kernels/asocial_rl_asymmetric.py
+++ b/src/comp_model/models/kernels/asocial_rl_asymmetric.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from comp_model.models.kernels.base import InitSpec, ModelKernelSpec, ParameterSpec
+from comp_model.models.kernels.base import InitSpec, ModelKernel, ModelKernelSpec, ParameterSpec
 from comp_model.models.kernels.probabilities import stable_softmax
 from comp_model.models.kernels.transforms import get_transform
 
@@ -50,7 +50,7 @@ class AsocialRlAsymmetricState:
     q_values: list[float]
 
 
-class AsocialRlAsymmetricKernel:
+class AsocialRlAsymmetricKernel(ModelKernel[AsocialRlAsymmetricState, AsocialRlAsymmetricParams]):
     """Asocial RL kernel with separate learning rates for positive and negative RPEs.
 
     The update rule is:

--- a/src/comp_model/models/kernels/base.py
+++ b/src/comp_model/models/kernels/base.py
@@ -25,8 +25,9 @@ without touching the infrastructure.
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic, Protocol, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -170,7 +171,7 @@ StateT = TypeVar("StateT")
 ParamsT = TypeVar("ParamsT")
 
 
-class ModelKernel(Protocol, Generic[StateT, ParamsT]):
+class ModelKernel(ABC, Generic[StateT, ParamsT]):
     """The interface that every computational model must implement.
 
     A ``ModelKernel`` is the heart of a computational model. It encodes two
@@ -202,6 +203,7 @@ class ModelKernel(Protocol, Generic[StateT, ParamsT]):
     """
 
     @classmethod
+    @abstractmethod
     def spec(cls) -> ModelKernelSpec:
         """Return the identity card (static metadata) for this model.
 
@@ -215,6 +217,7 @@ class ModelKernel(Protocol, Generic[StateT, ParamsT]):
 
         ...
 
+    @abstractmethod
     def parse_params(self, raw: dict[str, float]) -> ParamsT:
         """Convert raw numbers from the optimiser into this model's parameter object.
 
@@ -240,6 +243,7 @@ class ModelKernel(Protocol, Generic[StateT, ParamsT]):
 
         ...
 
+    @abstractmethod
     def initial_state(self, n_actions: int, params: ParamsT) -> StateT:
         """Create the participant's blank starting state before any learning.
 
@@ -265,6 +269,7 @@ class ModelKernel(Protocol, Generic[StateT, ParamsT]):
 
         ...
 
+    @abstractmethod
     def action_probabilities(
         self,
         state: StateT,
@@ -298,6 +303,7 @@ class ModelKernel(Protocol, Generic[StateT, ParamsT]):
 
         ...
 
+    @abstractmethod
     def update(
         self,
         state: StateT,

--- a/src/comp_model/models/kernels/social_rl_self_reward_demo_reward.py
+++ b/src/comp_model/models/kernels/social_rl_self_reward_demo_reward.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from comp_model.models.kernels.base import ModelKernelSpec, ParameterSpec
+from comp_model.models.kernels.base import ModelKernel, ModelKernelSpec, ParameterSpec
 from comp_model.models.kernels.probabilities import stable_softmax
 from comp_model.models.kernels.transforms import get_transform
 
@@ -81,7 +81,9 @@ class SocialRlSelfRewardDemoRewardState:
     q_values: list[float]
 
 
-class SocialRlSelfRewardDemoRewardKernel:
+class SocialRlSelfRewardDemoRewardKernel(
+    ModelKernel[SocialRlSelfRewardDemoRewardState, SocialRlSelfRewardDemoRewardParams]
+):
     """Q-learning model for a participant who learns from both personal and social experience.
 
     On each trial this model can update the participant's beliefs in two ways:


### PR DESCRIPTION
## Summary

- `ModelKernel` previously used `Protocol` (structural subtyping) — missing method implementations were only caught by pyright, not at runtime
- Switched to `ABC` so that instantiating an incomplete kernel raises `TypeError` immediately, giving a clearer error during development
- All five methods decorated with `@abstractmethod` (`spec` uses `@classmethod` + `@abstractmethod`)
- All three kernel classes now declare explicit inheritance: `ModelKernel[StateT, ParamsT]`

## Test plan

- [ ] All 139 tests pass (`uv run pytest -x -q`)
- [ ] Pre-commit hooks pass (ruff, ruff-format, pyright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)