### PR TITLE
fix(kernels): asocial kernels ignore social UPDATE steps

### DIFF
--- a/src/comp_model/models/kernels/asocial_q_learning.py
+++ b/src/comp_model/models/kernels/asocial_q_learning.py
@@ -238,6 +238,12 @@ class AsocialQLearningKernel(ModelKernel[QState, QParams]):
         If no reward is recorded for this trial (e.g. some task designs omit
         feedback on certain trials), the Q-values are returned unchanged.
 
+        Social UPDATE steps (where ``view.choice is None``) are silently
+        skipped. This makes the asocial kernel safe to fit against data
+        collected under a social schema — for example when comparing an
+        asocial model against a social model on the same dataset — without
+        requiring any changes to the data pipeline.
+
         Parameters
         ----------
         state
@@ -253,6 +259,11 @@ class AsocialQLearningKernel(ModelKernel[QState, QParams]):
         QState
             Updated Q-values to carry forward into the next trial.
         """
+
+        # Asocial model: ignore social UPDATE steps (e.g. when fitted to social
+        # schema data for model comparison). Only self-updates carry a choice.
+        if view.choice is None:
+            return state
 
         updated_q_values = list(state.q_values)
         if view.reward is not None:

--- a/src/comp_model/models/kernels/asocial_rl_asymmetric.py
+++ b/src/comp_model/models/kernels/asocial_rl_asymmetric.py
@@ -201,6 +201,10 @@ class AsocialRlAsymmetricKernel(ModelKernel[AsocialRlAsymmetricState, AsocialRlA
         Positive prediction errors (:math:`r > Q[a]`) use ``alpha_pos``;
         negative prediction errors (:math:`r < Q[a]`) use ``alpha_neg``.
 
+        Social UPDATE steps (where ``view.choice is None``) are silently
+        skipped, allowing this kernel to be fitted against data collected
+        under a social schema for model comparison purposes.
+
         Parameters
         ----------
         state
@@ -215,6 +219,11 @@ class AsocialRlAsymmetricKernel(ModelKernel[AsocialRlAsymmetricState, AsocialRlA
         AsocialRlAsymmetricState
             Updated latent state.
         """
+
+        # Asocial model: ignore social UPDATE steps (e.g. when fitted to social
+        # schema data for model comparison). Only self-updates carry a choice.
+        if view.choice is None:
+            return state
 
         updated_q_values = list(state.q_values)
         if view.reward is not None:

--- a/tests/test_models/test_asocial_q_learning.py
+++ b/tests/test_models/test_asocial_q_learning.py
@@ -49,3 +49,35 @@ def test_asocial_kernel_updates_chosen_q_value() -> None:
 
     assert updated_state.q_values[0] == 0.5
     assert updated_state.q_values[1] > 0.5
+
+
+def test_asocial_kernel_ignores_social_update_step() -> None:
+    """Ensure the asocial kernel leaves Q-values unchanged on social UPDATE steps.
+
+    When the asocial kernel is fitted to data collected under a social schema
+    (e.g. for model comparison), the replay engine emits UPDATE steps that
+    carry the demonstrator's outcome rather than the participant's own
+    choice.  These steps have ``choice=None`` and the kernel must ignore them
+    so that only the participant's own experience drives learning.
+
+    Returns
+    -------
+    None
+        This test asserts that social UPDATE steps are skipped.
+    """
+
+    kernel = AsocialQLearningKernel()
+    params = kernel.parse_params({"alpha": 0.5, "beta": 1.0})
+    state = kernel.initial_state(2, params)
+    social_view = DecisionTrialView(
+        trial_index=0,
+        available_actions=(0, 1),
+        choice=None,  # social UPDATE: demonstrator's step, no participant choice
+        reward=None,
+        social_action=0,
+        social_reward=1.0,
+    )
+
+    updated_state = kernel.update(state, social_view, params)
+
+    assert updated_state.q_values == state.q_values

--- a/tests/test_models/test_asocial_rl_asymmetric.py
+++ b/tests/test_models/test_asocial_rl_asymmetric.py
@@ -1,0 +1,112 @@
+"""Tests for the asocial asymmetric RL kernel."""
+
+import math
+
+from comp_model.data.extractors import DecisionTrialView
+from comp_model.models.kernels.asocial_rl_asymmetric import (
+    AsocialRlAsymmetricKernel,
+    AsocialRlAsymmetricState,
+)
+
+
+def test_asymmetric_kernel_action_probabilities_sum_to_one() -> None:
+    """Ensure asymmetric RL action probabilities are normalized.
+
+    Returns
+    -------
+    None
+        This test asserts probability normalization.
+    """
+
+    kernel = AsocialRlAsymmetricKernel()
+    params = kernel.parse_params({"alpha_pos": 0.0, "alpha_neg": 0.0, "beta": 1.0})
+    state = AsocialRlAsymmetricState(q_values=[0.25, 0.75])
+    view = DecisionTrialView(trial_index=0, available_actions=(0, 1), choice=1)
+
+    probabilities = kernel.action_probabilities(state, view, params)
+
+    assert math.isclose(sum(probabilities), 1.0, rel_tol=1e-12, abs_tol=1e-12)
+    assert probabilities[1] > probabilities[0]
+
+
+def test_asymmetric_kernel_positive_rpe_uses_alpha_pos() -> None:
+    """Ensure positive prediction errors use alpha_pos.
+
+    Returns
+    -------
+    None
+        This test asserts the asymmetric update for positive RPEs.
+    """
+
+    kernel = AsocialRlAsymmetricKernel()
+    # alpha_pos = 0.5 (sigmoid(0) ≈ 0.5), alpha_neg ≈ 0 (sigmoid(-10) ≈ 0)
+    params = kernel.parse_params({"alpha_pos": 0.0, "alpha_neg": -10.0, "beta": 1.0})
+    state = kernel.initial_state(2, params)
+    view = DecisionTrialView(
+        trial_index=0,
+        available_actions=(0, 1),
+        choice=1,
+        reward=1.0,  # reward > Q[1]=0.5 → positive RPE
+    )
+
+    updated_state = kernel.update(state, view, params)
+
+    assert updated_state.q_values[0] == 0.5
+    assert updated_state.q_values[1] > 0.5
+
+
+def test_asymmetric_kernel_negative_rpe_uses_alpha_neg() -> None:
+    """Ensure negative prediction errors use alpha_neg.
+
+    Returns
+    -------
+    None
+        This test asserts the asymmetric update for negative RPEs.
+    """
+
+    kernel = AsocialRlAsymmetricKernel()
+    # alpha_pos ≈ 0 (sigmoid(-10)), alpha_neg = 0.5 (sigmoid(0))
+    params = kernel.parse_params({"alpha_pos": -10.0, "alpha_neg": 0.0, "beta": 1.0})
+    state = kernel.initial_state(2, params)
+    view = DecisionTrialView(
+        trial_index=0,
+        available_actions=(0, 1),
+        choice=1,
+        reward=0.0,  # reward < Q[1]=0.5 → negative RPE
+    )
+
+    updated_state = kernel.update(state, view, params)
+
+    assert updated_state.q_values[0] == 0.5
+    assert updated_state.q_values[1] < 0.5
+
+
+def test_asymmetric_kernel_ignores_social_update_step() -> None:
+    """Ensure the asymmetric kernel leaves Q-values unchanged on social UPDATE steps.
+
+    When fitted to data collected under a social schema for model comparison,
+    the replay engine emits social UPDATE steps with ``choice=None``.  The
+    asocial kernel must ignore these so only the participant's own experience
+    drives learning.
+
+    Returns
+    -------
+    None
+        This test asserts that social UPDATE steps are skipped.
+    """
+
+    kernel = AsocialRlAsymmetricKernel()
+    params = kernel.parse_params({"alpha_pos": 0.0, "alpha_neg": 0.0, "beta": 1.0})
+    state = kernel.initial_state(2, params)
+    social_view = DecisionTrialView(
+        trial_index=0,
+        available_actions=(0, 1),
+        choice=None,  # social UPDATE: demonstrator's step, no participant choice
+        reward=None,
+        social_action=0,
+        social_reward=1.0,
+    )
+
+    updated_state = kernel.update(state, social_view, params)
+
+    assert updated_state.q_values == state.q_values


### PR DESCRIPTION
## Summary

- Added an explicit early-return guard (`if view.choice is None: return state`) to `AsocialQLearningKernel.update` and `AsocialRlAsymmetricKernel.update`
- Social UPDATE steps — emitted by the replay engine when the demonstrator acts — have `choice=None`; the asocial kernels now skip them rather than silently passing through
- This makes it safe to fit an asocial model against data collected under a social schema (e.g. for model comparison) without any changes to the data pipeline
- Updated docstrings to document this behaviour
- Added `test_asocial_kernel_ignores_social_update_step` to the Q-learning test file
- Created new `test_asocial_rl_asymmetric.py` covering all update paths plus the social-step guard

## Test plan

- [x] `uv run pytest tests/test_models/test_asocial_q_learning.py tests/test_models/test_asocial_rl_asymmetric.py -v` — all 7 tests pass
- [x] `uv run pytest -x -q` — full suite (144 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)