### PR TITLE
fix(kernels): update asocial social-update guard to new DecisionTrialView API

### DIFF
--- a/src/comp_model/models/kernels/asocial_q_learning.py
+++ b/src/comp_model/models/kernels/asocial_q_learning.py
@@ -238,9 +238,9 @@ class AsocialQLearningKernel(ModelKernel[QState, QParams]):
         If no reward is recorded for this trial (e.g. some task designs omit
         feedback on certain trials), the Q-values are returned unchanged.
 
-        Social UPDATE steps (where ``view.choice is None``) are silently
-        skipped. This makes the asocial kernel safe to fit against data
-        collected under a social schema — for example when comparing an
+        Social UPDATE steps (where ``view.actor_id != view.learner_id``) are
+        silently skipped. This makes the asocial kernel safe to fit against
+        data collected under a social schema — for example when comparing an
         asocial model against a social model on the same dataset — without
         requiring any changes to the data pipeline.
 
@@ -261,8 +261,9 @@ class AsocialQLearningKernel(ModelKernel[QState, QParams]):
         """
 
         # Asocial model: ignore social UPDATE steps (e.g. when fitted to social
-        # schema data for model comparison). Only self-updates carry a choice.
-        if view.choice is None:
+        # schema data for model comparison). Only self-updates have the learner
+        # acting as their own actor.
+        if view.actor_id != view.learner_id:
             return state
 
         updated_q_values = list(state.q_values)

--- a/src/comp_model/models/kernels/asocial_rl_asymmetric.py
+++ b/src/comp_model/models/kernels/asocial_rl_asymmetric.py
@@ -201,9 +201,9 @@ class AsocialRlAsymmetricKernel(ModelKernel[AsocialRlAsymmetricState, AsocialRlA
         Positive prediction errors (:math:`r > Q[a]`) use ``alpha_pos``;
         negative prediction errors (:math:`r < Q[a]`) use ``alpha_neg``.
 
-        Social UPDATE steps (where ``view.choice is None``) are silently
-        skipped, allowing this kernel to be fitted against data collected
-        under a social schema for model comparison purposes.
+        Social UPDATE steps (where ``view.actor_id != view.learner_id``) are
+        silently skipped, allowing this kernel to be fitted against data
+        collected under a social schema for model comparison purposes.
 
         Parameters
         ----------
@@ -221,8 +221,9 @@ class AsocialRlAsymmetricKernel(ModelKernel[AsocialRlAsymmetricState, AsocialRlA
         """
 
         # Asocial model: ignore social UPDATE steps (e.g. when fitted to social
-        # schema data for model comparison). Only self-updates carry a choice.
-        if view.choice is None:
+        # schema data for model comparison). Only self-updates have the learner
+        # acting as their own actor.
+        if view.actor_id != view.learner_id:
             return state
 
         updated_q_values = list(state.q_values)

--- a/tests/test_models/test_asocial_q_learning.py
+++ b/tests/test_models/test_asocial_q_learning.py
@@ -63,10 +63,10 @@ def test_asocial_kernel_ignores_social_update_step() -> None:
     """Ensure the asocial kernel leaves Q-values unchanged on social UPDATE steps.
 
     When the asocial kernel is fitted to data collected under a social schema
-    (e.g. for model comparison), the replay engine emits UPDATE steps that
-    carry the demonstrator's outcome rather than the participant's own
-    choice.  These steps have ``choice=None`` and the kernel must ignore them
-    so that only the participant's own experience drives learning.
+    (e.g. for model comparison), the replay engine emits UPDATE steps where
+    ``actor_id != learner_id`` — the demonstrator acted but the subject is
+    the learner.  The asocial kernel must ignore these so only the
+    participant's own experience drives learning.
 
     Returns
     -------
@@ -80,10 +80,10 @@ def test_asocial_kernel_ignores_social_update_step() -> None:
     social_view = DecisionTrialView(
         trial_index=0,
         available_actions=(0, 1),
-        choice=None,  # social UPDATE: demonstrator's step, no participant choice
-        reward=None,
-        social_action=0,
-        social_reward=1.0,
+        actor_id="demonstrator",  # social UPDATE: demonstrator acted
+        learner_id="subject",  # subject is the learner
+        action=0,
+        reward=1.0,
     )
 
     updated_state = kernel.update(state, social_view, params)

--- a/tests/test_models/test_asocial_rl_asymmetric.py
+++ b/tests/test_models/test_asocial_rl_asymmetric.py
@@ -21,7 +21,13 @@ def test_asymmetric_kernel_action_probabilities_sum_to_one() -> None:
     kernel = AsocialRlAsymmetricKernel()
     params = kernel.parse_params({"alpha_pos": 0.0, "alpha_neg": 0.0, "beta": 1.0})
     state = AsocialRlAsymmetricState(q_values=[0.25, 0.75])
-    view = DecisionTrialView(trial_index=0, available_actions=(0, 1), choice=1)
+    view = DecisionTrialView(
+        trial_index=0,
+        available_actions=(0, 1),
+        actor_id="subject",
+        learner_id="subject",
+        action=1,
+    )
 
     probabilities = kernel.action_probabilities(state, view, params)
 
@@ -45,7 +51,9 @@ def test_asymmetric_kernel_positive_rpe_uses_alpha_pos() -> None:
     view = DecisionTrialView(
         trial_index=0,
         available_actions=(0, 1),
-        choice=1,
+        actor_id="subject",
+        learner_id="subject",
+        action=1,
         reward=1.0,  # reward > Q[1]=0.5 → positive RPE
     )
 
@@ -71,7 +79,9 @@ def test_asymmetric_kernel_negative_rpe_uses_alpha_neg() -> None:
     view = DecisionTrialView(
         trial_index=0,
         available_actions=(0, 1),
-        choice=1,
+        actor_id="subject",
+        learner_id="subject",
+        action=1,
         reward=0.0,  # reward < Q[1]=0.5 → negative RPE
     )
 
@@ -85,9 +95,10 @@ def test_asymmetric_kernel_ignores_social_update_step() -> None:
     """Ensure the asymmetric kernel leaves Q-values unchanged on social UPDATE steps.
 
     When fitted to data collected under a social schema for model comparison,
-    the replay engine emits social UPDATE steps with ``choice=None``.  The
-    asocial kernel must ignore these so only the participant's own experience
-    drives learning.
+    the replay engine emits social UPDATE steps where ``actor_id != learner_id``
+    — the demonstrator acted but the subject is the learner.  The asocial
+    kernel must ignore these so only the participant's own experience drives
+    learning.
 
     Returns
     -------
@@ -101,10 +112,10 @@ def test_asymmetric_kernel_ignores_social_update_step() -> None:
     social_view = DecisionTrialView(
         trial_index=0,
         available_actions=(0, 1),
-        choice=None,  # social UPDATE: demonstrator's step, no participant choice
-        reward=None,
-        social_action=0,
-        social_reward=1.0,
+        actor_id="demonstrator",  # social UPDATE: demonstrator acted
+        learner_id="subject",  # subject is the learner
+        action=0,
+        reward=1.0,
     )
 
     updated_state = kernel.update(state, social_view, params)


### PR DESCRIPTION
## Summary

- Fixes CI failure introduced when PR #40 and PR #41 merged in the wrong order
- PR #40 removed `view.choice`, `view.social_action`, `view.social_reward` from `DecisionTrialView`; PR #41's guard still referenced the now-gone `view.choice is None`
- Replace the guard in `AsocialQLearningKernel.update` and `AsocialRlAsymmetricKernel.update` with `view.actor_id != view.learner_id`
- Update all test fixtures to use `actor_id`, `learner_id`, `action` in place of the old fields

## Test plan

- [x] `uv run pytest tests/test_models/ -v` — all 21 tests pass
- [x] `uv run pytest -x -q` — full suite (144 tests) passes
- [x] pyright passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)