### PR TITLE
refactor(kernels): drive parse_params transforms from spec()

### DIFF
--- a/src/comp_model/models/kernels/asocial_q_learning.py
+++ b/src/comp_model/models/kernels/asocial_q_learning.py
@@ -150,9 +150,10 @@ class AsocialQLearningKernel(ModelKernel[QState, QParams]):
             ready for use in ``action_probabilities`` and ``update``.
         """
 
+        transforms = {ps.name: get_transform(ps.transform_id) for ps in self.spec().parameter_specs}
         return QParams(
-            alpha=get_transform("sigmoid").forward(raw["alpha"]),
-            beta=get_transform("softplus").forward(raw["beta"]),
+            alpha=transforms["alpha"].forward(raw["alpha"]),
+            beta=transforms["beta"].forward(raw["beta"]),
         )
 
     def initial_state(self, n_actions: int, params: QParams) -> QState:

--- a/src/comp_model/models/kernels/asocial_rl_asymmetric.py
+++ b/src/comp_model/models/kernels/asocial_rl_asymmetric.py
@@ -137,10 +137,11 @@ class AsocialRlAsymmetricKernel(ModelKernel[AsocialRlAsymmetricState, AsocialRlA
             Typed parameter object after applying the shared transform registry.
         """
 
+        transforms = {ps.name: get_transform(ps.transform_id) for ps in self.spec().parameter_specs}
         return AsocialRlAsymmetricParams(
-            alpha_pos=get_transform("sigmoid").forward(raw["alpha_pos"]),
-            alpha_neg=get_transform("sigmoid").forward(raw["alpha_neg"]),
-            beta=get_transform("softplus").forward(raw["beta"]),
+            alpha_pos=transforms["alpha_pos"].forward(raw["alpha_pos"]),
+            alpha_neg=transforms["alpha_neg"].forward(raw["alpha_neg"]),
+            beta=transforms["beta"].forward(raw["beta"]),
         )
 
     def initial_state(

--- a/src/comp_model/models/kernels/social_rl_self_reward_demo_mixture.py
+++ b/src/comp_model/models/kernels/social_rl_self_reward_demo_mixture.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from comp_model.models.kernels.base import ModelKernel, ModelKernelSpec, ParameterSpec
+from comp_model.models.kernels.transforms import get_transform
+
+
+@dataclass(frozen=True, slots=True)
+class SocialRlSelfRewardDemoMixtureParams:
+    alpha_self: float
+    alpha_other_outcome: float
+    alpha_other_action: float
+    weight_action: float
+    beta: float
+
+
+@dataclass(slots=True)
+class SocialRlSelfRewardDemoMixtureState:
+    q_reward: list[float]  # updated by self reward + demo reward (outcome tracker)
+    q_action: list[float]  # updated by demo action frequency (action tracker)
+
+
+class SocialRlSelfRewardDemoMixtureKernel(
+    ModelKernel[SocialRlSelfRewardDemoMixtureState, SocialRlSelfRewardDemoMixtureParams]
+):
+    @classmethod
+    def spec(cls) -> ModelKernelSpec:
+        return ModelKernelSpec(
+            model_id="social_rl_self_reward_demo_mixture",
+            parameter_specs=(
+                ParameterSpec(
+                    name="alpha_self",
+                    transform_id="sigmoid",
+                    description="learning from self outcome",
+                ),
+                ParameterSpec(
+                    name="alpha_other_outcome",
+                    transform_id="sigmoid",
+                    description="learning from other outcome",
+                ),
+                ParameterSpec(
+                    name="alpha_other_action",
+                    transform_id="sigmoid",
+                    description="learning from other action",
+                ),
+                ParameterSpec(
+                    name="weight_action",
+                    transform_id="sigmoid",
+                    description="weight of learning from other action",
+                ),
+                ParameterSpec(
+                    name="beta",
+                    transform_id="softplus",
+                    description="inverse temperature",
+                ),
+            ),
+            requires_social=True,
+        )
+
+    def parse_params(self, raw: dict[str, float]) -> SocialRlSelfRewardDemoMixtureParams:
+        transforms = {ps.name: get_transform(ps.transform_id) for ps in self.spec().parameter_specs}
+        return SocialRlSelfRewardDemoMixtureParams(
+            alpha_self=transforms["alpha_self"].forward(raw["alpha_self"]),
+            alpha_other_outcome=transforms["alpha_other_outcome"].forward(
+                raw["alpha_other_outcome"]
+            ),
+            alpha_other_action=transforms["alpha_other_action"].forward(raw["alpha_other_action"]),
+            weight_action=transforms["weight_action"].forward(raw["weight_action"]),
+            beta=transforms["beta"].forward(raw["beta"]),
+        )

--- a/src/comp_model/models/kernels/social_rl_self_reward_demo_reward.py
+++ b/src/comp_model/models/kernels/social_rl_self_reward_demo_reward.py
@@ -165,10 +165,11 @@ class SocialRlSelfRewardDemoRewardKernel(
             Parameter object with all three parameters on their natural scales.
         """
 
+        transforms = {ps.name: get_transform(ps.transform_id) for ps in self.spec().parameter_specs}
         return SocialRlSelfRewardDemoRewardParams(
-            alpha_self=get_transform("sigmoid").forward(raw["alpha_self"]),
-            alpha_other=get_transform("sigmoid").forward(raw["alpha_other"]),
-            beta=get_transform("softplus").forward(raw["beta"]),
+            alpha_self=transforms["alpha_self"].forward(raw["alpha_self"]),
+            alpha_other=transforms["alpha_other"].forward(raw["alpha_other"]),
+            beta=transforms["beta"].forward(raw["beta"]),
         )
 
     def initial_state(


### PR DESCRIPTION
## Summary

- `spec().parameter_specs` is now the single source of truth for each parameter's transform
- `parse_params` builds a `{name: transform}` dict from `spec()` instead of hardcoding transform IDs — changing a `transform_id` in `spec()` now automatically propagates to `parse_params`
- Fixes a typo in `social_rl_self_reward_demo_mixture`: raw key was `"alpha_ohter_action"` (transposed letters), now correctly `"alpha_other_action"`

## Test plan
- [x] All existing kernel tests pass (`tests/test_models/`)
- [x] Verify that changing a `transform_id` in `spec()` is reflected in `parse_params` without any other edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)