### PR TITLE
refactor(kernels): remove initial_value from ModelKernelSpec

### DIFF
--- a/src/comp_model/inference/bayes/stan/adapters/asocial_q_learning.py
+++ b/src/comp_model/inference/bayes/stan/adapters/asocial_q_learning.py
@@ -128,7 +128,7 @@ class AsocialQLearningStanAdapter:
         # Add prior, reset, and initial value data
         add_prior_data(stan_data, kspec, prior_specs)
         add_state_reset_data(stan_data, kspec)
-        add_initial_value_data(stan_data, kspec)
+        add_initial_value_data(stan_data, 0.5)
 
         # Add condition metadata for condition-aware hierarchies
         if layout is not None and condition_map is not None:

--- a/src/comp_model/inference/bayes/stan/adapters/asocial_rl_asymmetric.py
+++ b/src/comp_model/inference/bayes/stan/adapters/asocial_rl_asymmetric.py
@@ -68,7 +68,7 @@ class AsocialRlAsymmetricStanAdapter:
 
         add_prior_data(stan_data, kspec, prior_specs)
         add_state_reset_data(stan_data, kspec)
-        add_initial_value_data(stan_data, kspec)
+        add_initial_value_data(stan_data, 0.5)
 
         if layout is not None and condition_map is not None:
             stan_data["C"] = len(layout.conditions)

--- a/src/comp_model/inference/bayes/stan/adapters/social_rl_self_reward_demo_reward.py
+++ b/src/comp_model/inference/bayes/stan/adapters/social_rl_self_reward_demo_reward.py
@@ -71,7 +71,7 @@ class SocialRlSelfRewardDemoRewardStanAdapter:
 
         add_prior_data(stan_data, kspec, prior_specs)
         add_state_reset_data(stan_data, kspec)
-        add_initial_value_data(stan_data, kspec)
+        add_initial_value_data(stan_data, 0.5)
 
         if layout is not None and condition_map is not None:
             stan_data["C"] = len(layout.conditions)

--- a/src/comp_model/inference/bayes/stan/data_builder.py
+++ b/src/comp_model/inference/bayes/stan/data_builder.py
@@ -243,15 +243,17 @@ def add_condition_data_dataset(
     stan_data["cond"] = condition_index
 
 
-def add_initial_value_data(stan_data: dict[str, Any], kernel_spec: ModelKernelSpec) -> None:
-    """Add the initial state value to a Stan data dictionary.
+def add_initial_value_data(stan_data: dict[str, Any], initial_value: float) -> None:
+    """Add the initial Q-value to a Stan data dictionary.
 
     Parameters
     ----------
     stan_data
         Stan data dictionary to mutate.
-    kernel_spec
-        Kernel specification whose initial value should be exported.
+    initial_value
+        Starting value assigned to all Q-values before any learning occurs.
+        Each kernel's ``initial_state`` owns this value; the caller is
+        responsible for passing the correct constant here.
 
     Returns
     -------
@@ -259,7 +261,7 @@ def add_initial_value_data(stan_data: dict[str, Any], kernel_spec: ModelKernelSp
         This function mutates ``stan_data`` in-place.
     """
 
-    stan_data["q_init"] = float(kernel_spec.initial_value)
+    stan_data["q_init"] = float(initial_value)
 
 
 def add_prior_data(

--- a/src/comp_model/models/kernels/asocial_q_learning.py
+++ b/src/comp_model/models/kernels/asocial_q_learning.py
@@ -177,7 +177,7 @@ class AsocialQLearningKernel(ModelKernel[QState, QParams]):
         """
 
         del params
-        return QState(q_values=[self.spec().initial_value] * n_actions)
+        return QState(q_values=[0.5] * n_actions)
 
     def action_probabilities(
         self,

--- a/src/comp_model/models/kernels/asocial_rl_asymmetric.py
+++ b/src/comp_model/models/kernels/asocial_rl_asymmetric.py
@@ -162,7 +162,7 @@ class AsocialRlAsymmetricKernel(ModelKernel[AsocialRlAsymmetricState, AsocialRlA
         """
 
         del params
-        return AsocialRlAsymmetricState(q_values=[self.spec().initial_value] * n_actions)
+        return AsocialRlAsymmetricState(q_values=[0.5] * n_actions)
 
     def action_probabilities(
         self,

--- a/src/comp_model/models/kernels/base.py
+++ b/src/comp_model/models/kernels/base.py
@@ -153,9 +153,6 @@ class ModelKernelSpec:
         - ``"continuous"``: state accumulates across all blocks; learning
           carries over from one block to the next (e.g. multi-condition
           within-subject designs).
-    initial_value
-        The starting value assigned to each Q-value (or equivalent
-        quantity) before any learning occurs. Defaults to 0.5.
     description
         A plain-English summary of the model, used in reports and logs.
     """
@@ -165,7 +162,6 @@ class ModelKernelSpec:
     requires_social: bool = False
     n_actions: int | None = None
     state_reset_policy: Literal["per_block", "continuous"] = "per_block"
-    initial_value: float = 0.5
     description: str = ""
 
 

--- a/src/comp_model/models/kernels/social_rl_self_reward_demo_reward.py
+++ b/src/comp_model/models/kernels/social_rl_self_reward_demo_reward.py
@@ -195,7 +195,7 @@ class SocialRlSelfRewardDemoRewardKernel(
         """
 
         del params
-        return SocialRlSelfRewardDemoRewardState(q_values=[self.spec().initial_value] * n_actions)
+        return SocialRlSelfRewardDemoRewardState(q_values=[0.5] * n_actions)
 
     def action_probabilities(
         self,


### PR DESCRIPTION
## Summary

- `initial_value: float = 0.5` removed from `ModelKernelSpec` — a single scalar can't represent multi-system models like the mixture kernel (which needs separate init values for `q_reward` and `q_action` on different scales)
- Each kernel's `initial_state` now owns its initialization: single-system kernels hardcode `0.5`; future multi-system kernels can initialize each system independently
- `add_initial_value_data` signature changed from `(stan_data, kernel_spec)` to `(stan_data, initial_value: float)` — callers pass the constant directly
- Stan programs unchanged — `q_init` remains a data variable

## Test plan
- [ ] All 144 tests pass
- [ ] Confirm new mixture kernel can define `q_reward=[0.5]*n` and `q_action=[0.0]*n` without touching spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)