### PR TITLE
feat(mixture/examples): add within-subject, no-pooling, and block-recovery scripts

### DIFF
--- a/example/social_rl_self_reward_demo_mixture/check_block_recovery.py
+++ b/example/social_rl_self_reward_demo_mixture/check_block_recovery.py
@@ -1,0 +1,103 @@
+"""Check whether increasing trials improves parameter recovery for the mixture model."""
+
+import numpy as np
+
+from comp_model.environments import StationaryBanditEnvironment
+from comp_model.inference import fit
+from comp_model.inference.config import HierarchyStructure, InferenceConfig
+from comp_model.inference.mle.optimize import MleOptimizerConfig
+from comp_model.models.kernels import (
+    AsocialQLearningKernel,
+    QParams,
+    SocialRlSelfRewardDemoMixtureKernel,
+    SocialRlSelfRewardDemoMixtureParams,
+)
+from comp_model.runtime import SimulationConfig, simulate_dataset
+from comp_model.tasks import SOCIAL_PRE_CHOICE_SCHEMA, BlockSpec, TaskSpec
+
+N_ACTIONS = 2
+REWARD_PROBS = (0.8, 0.2)
+TRUE_ALPHA_SELF = 0.3
+TRUE_ALPHA_OTHER_OUTCOME = 0.2
+TRUE_ALPHA_OTHER_ACTION = 0.4
+TRUE_W_IMITATION = 0.3
+TRUE_BETA = 2.0
+N_SUBJECTS = 20
+TRIALS_PER_BLOCK = 50
+
+kernel = SocialRlSelfRewardDemoMixtureKernel()
+true_params = SocialRlSelfRewardDemoMixtureParams(
+    alpha_self=TRUE_ALPHA_SELF,
+    alpha_other_outcome=TRUE_ALPHA_OTHER_OUTCOME,
+    alpha_other_action=TRUE_ALPHA_OTHER_ACTION,
+    w_imitation=TRUE_W_IMITATION,
+    beta=TRUE_BETA,
+)
+
+mle_config = InferenceConfig(
+    hierarchy=HierarchyStructure.SUBJECT_SHARED,
+    backend="mle",
+    mle_config=MleOptimizerConfig(n_restarts=10, seed=0),
+)
+
+param_names = ("alpha_self", "alpha_other_outcome", "alpha_other_action", "w_imitation", "beta")
+true_vals = (
+    TRUE_ALPHA_SELF,
+    TRUE_ALPHA_OTHER_OUTCOME,
+    TRUE_ALPHA_OTHER_ACTION,
+    TRUE_W_IMITATION,
+    TRUE_BETA,
+)
+
+header = f"{'Blocks':>6}  {'Trials':>6}  " + "  ".join(
+    f"{'mean_' + p[:4]:>10} {'std_' + p[:4]:>9}" for p in param_names
+)
+print(header)
+print("-" * len(header))
+
+for n_blocks in [1, 2, 4, 8]:
+    total_trials = n_blocks * TRIALS_PER_BLOCK
+    task = TaskSpec(
+        task_id="test",
+        blocks=tuple(
+            BlockSpec(
+                condition="social",
+                n_trials=TRIALS_PER_BLOCK,
+                schema=SOCIAL_PRE_CHOICE_SCHEMA,
+                metadata={"n_actions": N_ACTIONS},
+            )
+            for _ in range(n_blocks)
+        ),
+    )
+
+    params_per_subject = {f"sub_{i:02d}": true_params for i in range(N_SUBJECTS)}
+    dataset = simulate_dataset(
+        task=task,
+        env_factory=lambda: StationaryBanditEnvironment(
+            n_actions=N_ACTIONS, reward_probs=REWARD_PROBS
+        ),
+        kernel=kernel,
+        params_per_subject=params_per_subject,
+        config=SimulationConfig(seed=42),
+        demonstrator_kernel=AsocialQLearningKernel(),
+        demonstrator_params=QParams(alpha=0.0, beta=0.0),
+    )
+
+    recovered: dict[str, list[float]] = {p: [] for p in param_names}
+    for subject in dataset.subjects:
+        result = fit(mle_config, kernel, subject, SOCIAL_PRE_CHOICE_SCHEMA)
+        for p in param_names:
+            recovered[p].append(result.constrained_params[p])
+
+    row = f"{n_blocks:>6}  {total_trials:>6}  "
+    row += "  ".join(
+        f"{np.mean(recovered[p]):>10.3f} {np.std(recovered[p]):>9.3f}" for p in param_names
+    )
+    print(row)
+
+print(
+    f"\nTrue values: alpha_self={TRUE_ALPHA_SELF}, "
+    f"alpha_other_outcome={TRUE_ALPHA_OTHER_OUTCOME}, "
+    f"alpha_other_action={TRUE_ALPHA_OTHER_ACTION}, "
+    f"w_imitation={TRUE_W_IMITATION}, beta={TRUE_BETA}"
+)

--- a/example/social_rl_self_reward_demo_mixture/mle_within_subject.py
+++ b/example/social_rl_self_reward_demo_mixture/mle_within_subject.py
@@ -1,0 +1,164 @@
+"""Simulate mixture social RL agents with two social conditions, then recover
+condition-specific parameters with per-subject MLE using SharedDeltaLayout.
+
+Within-subject design: each subject experiences both conditions. The model
+estimates a shared baseline parameter set plus additive deltas for the
+non-baseline condition on the unconstrained scale.
+
+Ground-truth:
+  Condition "social_low"  (baseline): alpha_self=0.3, alpha_other_outcome=0.1,
+                                       alpha_other_action=0.2, w_imitation=0.2, beta=2.0
+  Condition "social_high":             alpha_self=0.3, alpha_other_outcome=0.4,
+                                       alpha_other_action=0.6, w_imitation=0.5, beta=2.0
+"""
+
+from pathlib import Path
+
+from comp_model.data import Block, Dataset, SubjectData
+from comp_model.environments import StationaryBanditEnvironment
+from comp_model.inference import fit
+from comp_model.inference.config import HierarchyStructure, InferenceConfig
+from comp_model.inference.mle.optimize import MleOptimizerConfig
+from comp_model.io import save_dataset_to_csv
+from comp_model.models import SharedDeltaLayout
+from comp_model.models.kernels import (
+    AsocialQLearningKernel,
+    QParams,
+    SocialRlSelfRewardDemoMixtureKernel,
+    SocialRlSelfRewardDemoMixtureParams,
+)
+from comp_model.models.kernels.transforms import get_transform
+from comp_model.runtime import SimulationConfig, simulate_subject
+from comp_model.tasks import SOCIAL_PRE_CHOICE_SCHEMA, BlockSpec, TaskSpec
+
+# ── 1. Define task with two conditions ──────────────────────────────────────
+N_ACTIONS = 2
+N_TRIALS = 100
+N_SUBJECTS = 5
+REWARD_PROBS = (0.8, 0.2)
+
+task = TaskSpec(
+    task_id="social_mixture_within",
+    blocks=(
+        BlockSpec(
+            condition="social_low",
+            n_trials=N_TRIALS,
+            schema=SOCIAL_PRE_CHOICE_SCHEMA,
+            metadata={"n_actions": N_ACTIONS},
+        ),
+        BlockSpec(
+            condition="social_high",
+            n_trials=N_TRIALS,
+            schema=SOCIAL_PRE_CHOICE_SCHEMA,
+            metadata={"n_actions": N_ACTIONS},
+        ),
+    ),
+)
+
+# ── 2. Ground-truth parameters per condition ────────────────────────────────
+TRUE_PARAMS = {
+    "social_low": SocialRlSelfRewardDemoMixtureParams(
+        alpha_self=0.3,
+        alpha_other_outcome=0.1,
+        alpha_other_action=0.2,
+        w_imitation=0.2,
+        beta=2.0,
+    ),
+    "social_high": SocialRlSelfRewardDemoMixtureParams(
+        alpha_self=0.3,
+        alpha_other_outcome=0.4,
+        alpha_other_action=0.6,
+        w_imitation=0.5,
+        beta=2.0,
+    ),
+}
+
+kernel = SocialRlSelfRewardDemoMixtureKernel()
+
+# ── 3. Set up condition-aware layout ────────────────────────────────────────
+layout = SharedDeltaLayout(
+    kernel_spec=kernel.spec(),
+    conditions=("social_low", "social_high"),
+    baseline_condition="social_low",
+)
+
+print(f"Layout parameter keys: {layout.parameter_keys()}")
+print(f"Number of params: {layout.n_params()}")
+
+# ── 4. Simulate dataset ────────────────────────────────────────────────────
+subjects = []
+for i in range(N_SUBJECTS):
+    sid = f"sub_{i:02d}"
+    blocks = []
+    for block_idx, block_spec in enumerate(task.blocks):
+        condition = block_spec.condition
+        sub = simulate_subject(
+            task=TaskSpec(task_id="tmp", blocks=(block_spec,)),
+            env=StationaryBanditEnvironment(n_actions=N_ACTIONS, reward_probs=REWARD_PROBS),
+            kernel=kernel,
+            params=TRUE_PARAMS[condition],
+            config=SimulationConfig(seed=42 + i + block_idx * 100),
+            subject_id=sid,
+            demonstrator_kernel=AsocialQLearningKernel(),
+            demonstrator_params=QParams(alpha=0.0, beta=0.0),
+        )
+        blocks.append(
+            Block(
+                block_index=block_idx,
+                condition=sub.blocks[0].condition,
+                trials=sub.blocks[0].trials,
+            )
+        )
+    subjects.append(SubjectData(subject_id=sid, blocks=tuple(blocks)))
+
+dataset = Dataset(subjects=tuple(subjects))
+
+# ── 5. Save to CSV ─────────────────────────────────────────────────────────
+csv_path = Path(__file__).parent / "within_subject_data.csv"
+save_dataset_to_csv(dataset, schema=SOCIAL_PRE_CHOICE_SCHEMA, path=csv_path)
+print(f"\nSaved {len(dataset.subjects)} subjects x {len(task.blocks)} blocks to {csv_path}")
+
+# ── 6. Fit each subject with condition-aware MLE ───────────────────────────
+mle_config = InferenceConfig(
+    hierarchy=HierarchyStructure.SUBJECT_BLOCK_CONDITION,
+    backend="mle",
+    mle_config=MleOptimizerConfig(n_restarts=20, seed=0),
+)
+
+sigmoid = get_transform("sigmoid")
+softplus = get_transform("softplus")
+
+params_to_show = ("alpha_self", "alpha_other_outcome", "alpha_other_action", "w_imitation", "beta")
+transforms = {
+    "alpha_self": sigmoid,
+    "alpha_other_outcome": sigmoid,
+    "alpha_other_action": sigmoid,
+    "w_imitation": sigmoid,
+    "beta": softplus,
+}
+
+print(
+    f"\n{'Subject':<10} {'Cond':<14} "
+    + " ".join(f"{'True ' + p[:4]:>9} {'Fit ' + p[:4]:>9}" for p in params_to_show)
+)
+print("-" * (10 + 14 + 19 * len(params_to_show)))
+
+for subject in dataset.subjects:
+    result = fit(mle_config, kernel, subject, SOCIAL_PRE_CHOICE_SCHEMA, layout=layout)
+    for condition in ("social_low", "social_high"):
+        true_p = TRUE_PARAMS[condition]
+        fit_p = result.params_by_condition[condition]
+        true_vals = [
+            true_p.alpha_self,
+            true_p.alpha_other_outcome,
+            true_p.alpha_other_action,
+            true_p.w_imitation,
+            true_p.beta,
+        ]
+        fit_vals = [transforms[p].forward(fit_p[p]) for p in params_to_show]
+        row = f"{subject.subject_id:<10} {condition:<14} "
+        row += " ".join(f"{t:>9.3f} {f:>9.3f}" for t, f in zip(true_vals, fit_vals, strict=True))
+        print(row)
+    print(f"  -> LL={result.log_likelihood:.2f}, AIC={result.aic:.2f}, BIC={result.bic:.2f}")
+
+print("\nDone.")

--- a/example/social_rl_self_reward_demo_mixture/stan_hierarchical_within_subject.py
+++ b/example/social_rl_self_reward_demo_mixture/stan_hierarchical_within_subject.py
@@ -1,0 +1,281 @@
+"""Simulate mixture social RL agents with two within-subject conditions, then
+recover parameters with hierarchical Stan (NUTS) inference using SharedDeltaLayout.
+
+Combines population-level estimation with within-subject conditions:
+  - Each subject experiences both "social_low" and "social_high" conditions
+  - Per-subject parameters are drawn from a population distribution
+  - The model uses shared baseline + delta parameterisation across conditions
+  - Population-level mu/sd are estimated for both shared and delta parameters
+
+Hierarchy: STUDY_SUBJECT_BLOCK_CONDITION
+  Population:  mu/sd for each of alpha_self, alpha_other_outcome,
+               alpha_other_action, w_imitation, beta (shared and delta)
+  Subject:     all 5 parameters per condition (constrained)
+
+Ground-truth:
+  Condition "social_low"  (baseline): alpha_self=0.3, alpha_other_outcome=0.1,
+                                       alpha_other_action=0.2, w_imitation=0.2, beta=2.0
+  Condition "social_high":             alpha_self=0.3, alpha_other_outcome=0.4,
+                                       alpha_other_action=0.6, w_imitation=0.5, beta=2.0
+
+Requires: cmdstanpy and a working CmdStan installation.
+
+Usage:
+    uv run python example/social_rl_self_reward_demo_mixture/stan_hierarchical_within_subject.py
+"""
+
+from pathlib import Path
+
+import numpy as np
+from scipy.special import expit as sigmoid_vec
+from scipy.special import logit as inv_sigmoid_vec
+
+from comp_model.data import Block, Dataset, SubjectData
+from comp_model.environments import StationaryBanditEnvironment
+from comp_model.inference import fit
+from comp_model.inference.bayes.stan import (
+    SocialRlSelfRewardDemoMixtureStanAdapter,
+    StanFitConfig,
+)
+from comp_model.inference.config import HierarchyStructure, InferenceConfig
+from comp_model.io import save_dataset_to_csv
+from comp_model.models import SharedDeltaLayout
+from comp_model.models.kernels import (
+    AsocialQLearningKernel,
+    QParams,
+    SocialRlSelfRewardDemoMixtureKernel,
+    SocialRlSelfRewardDemoMixtureParams,
+)
+from comp_model.runtime import SimulationConfig, simulate_subject
+from comp_model.tasks import SOCIAL_PRE_CHOICE_SCHEMA, BlockSpec, TaskSpec
+
+
+def softplus_vec(x: np.ndarray) -> np.ndarray:
+    """Apply softplus element-wise: log(1 + exp(x))."""
+    return np.log1p(np.exp(x))
+
+
+def inv_softplus_vec(x: np.ndarray) -> np.ndarray:
+    """Invert softplus element-wise: log(exp(x) - 1)."""
+    return np.log(np.expm1(x))
+
+
+# ── 1. Define task with two conditions ──────────────────────────────────────
+N_ACTIONS = 2
+N_TRIALS = 200
+N_SUBJECTS = 15
+REWARD_PROBS = (0.8, 0.2)
+
+task = TaskSpec(
+    task_id="social_mixture_within",
+    blocks=(
+        BlockSpec(
+            condition="social_low",
+            n_trials=N_TRIALS,
+            schema=SOCIAL_PRE_CHOICE_SCHEMA,
+            metadata={"n_actions": N_ACTIONS},
+        ),
+        BlockSpec(
+            condition="social_high",
+            n_trials=N_TRIALS,
+            schema=SOCIAL_PRE_CHOICE_SCHEMA,
+            metadata={"n_actions": N_ACTIONS},
+        ),
+    ),
+)
+
+# ── 2. Ground-truth population parameters ───────────────────────────────────
+kernel = SocialRlSelfRewardDemoMixtureKernel()
+
+# Baseline ("social_low") population means on unconstrained scale
+TRUE_MU_ALPHA_SELF_SHARED_Z = float(inv_sigmoid_vec(0.3))
+TRUE_SD_ALPHA_SELF_SHARED_Z = 0.3
+TRUE_MU_ALPHA_OTHER_OUTCOME_SHARED_Z = float(inv_sigmoid_vec(0.1))
+TRUE_SD_ALPHA_OTHER_OUTCOME_SHARED_Z = 0.3
+TRUE_MU_ALPHA_OTHER_ACTION_SHARED_Z = float(inv_sigmoid_vec(0.2))
+TRUE_SD_ALPHA_OTHER_ACTION_SHARED_Z = 0.3
+TRUE_MU_W_IMITATION_SHARED_Z = float(inv_sigmoid_vec(0.2))
+TRUE_SD_W_IMITATION_SHARED_Z = 0.3
+TRUE_MU_BETA_SHARED_Z = float(inv_softplus_vec(np.array(2.0)))
+TRUE_SD_BETA_SHARED_Z = 0.3
+
+# Delta ("social_high" - "social_low") population means on unconstrained scale
+TRUE_MU_ALPHA_OTHER_OUTCOME_DELTA_Z = float(inv_sigmoid_vec(0.4) - inv_sigmoid_vec(0.1))
+TRUE_SD_ALPHA_OTHER_OUTCOME_DELTA_Z = 0.2
+TRUE_MU_ALPHA_OTHER_ACTION_DELTA_Z = float(inv_sigmoid_vec(0.6) - inv_sigmoid_vec(0.2))
+TRUE_SD_ALPHA_OTHER_ACTION_DELTA_Z = 0.2
+TRUE_MU_W_IMITATION_DELTA_Z = float(inv_sigmoid_vec(0.5) - inv_sigmoid_vec(0.2))
+TRUE_SD_W_IMITATION_DELTA_Z = 0.2
+# alpha_self and beta do not differ across conditions: delta mean = 0
+TRUE_MU_ALPHA_SELF_DELTA_Z = 0.0
+TRUE_SD_ALPHA_SELF_DELTA_Z = 0.2
+TRUE_MU_BETA_DELTA_Z = 0.0
+TRUE_SD_BETA_DELTA_Z = 0.2
+
+# ── 3. Sample per-subject parameters from population ────────────────────────
+rng = np.random.default_rng(123)
+
+alpha_self_shared_z = rng.normal(
+    TRUE_MU_ALPHA_SELF_SHARED_Z, TRUE_SD_ALPHA_SELF_SHARED_Z, N_SUBJECTS
+)
+aoo_shared_z = rng.normal(
+    TRUE_MU_ALPHA_OTHER_OUTCOME_SHARED_Z, TRUE_SD_ALPHA_OTHER_OUTCOME_SHARED_Z, N_SUBJECTS
+)
+aoa_shared_z = rng.normal(
+    TRUE_MU_ALPHA_OTHER_ACTION_SHARED_Z, TRUE_SD_ALPHA_OTHER_ACTION_SHARED_Z, N_SUBJECTS
+)
+wi_shared_z = rng.normal(TRUE_MU_W_IMITATION_SHARED_Z, TRUE_SD_W_IMITATION_SHARED_Z, N_SUBJECTS)
+beta_shared_z = rng.normal(TRUE_MU_BETA_SHARED_Z, TRUE_SD_BETA_SHARED_Z, N_SUBJECTS)
+
+alpha_self_delta_z = rng.normal(TRUE_MU_ALPHA_SELF_DELTA_Z, TRUE_SD_ALPHA_SELF_DELTA_Z, N_SUBJECTS)
+aoo_delta_z = rng.normal(
+    TRUE_MU_ALPHA_OTHER_OUTCOME_DELTA_Z, TRUE_SD_ALPHA_OTHER_OUTCOME_DELTA_Z, N_SUBJECTS
+)
+aoa_delta_z = rng.normal(
+    TRUE_MU_ALPHA_OTHER_ACTION_DELTA_Z, TRUE_SD_ALPHA_OTHER_ACTION_DELTA_Z, N_SUBJECTS
+)
+wi_delta_z = rng.normal(TRUE_MU_W_IMITATION_DELTA_Z, TRUE_SD_W_IMITATION_DELTA_Z, N_SUBJECTS)
+beta_delta_z = rng.normal(TRUE_MU_BETA_DELTA_Z, TRUE_SD_BETA_DELTA_Z, N_SUBJECTS)
+
+TRUE_PARAMS_PER_SUBJECT: dict[str, dict[str, SocialRlSelfRewardDemoMixtureParams]] = {}
+for i in range(N_SUBJECTS):
+    sid = f"sub_{i:02d}"
+    TRUE_PARAMS_PER_SUBJECT[sid] = {
+        "social_low": SocialRlSelfRewardDemoMixtureParams(
+            alpha_self=float(sigmoid_vec(alpha_self_shared_z[i])),
+            alpha_other_outcome=float(sigmoid_vec(aoo_shared_z[i])),
+            alpha_other_action=float(sigmoid_vec(aoa_shared_z[i])),
+            w_imitation=float(sigmoid_vec(wi_shared_z[i])),
+            beta=float(softplus_vec(beta_shared_z[i])),
+        ),
+        "social_high": SocialRlSelfRewardDemoMixtureParams(
+            alpha_self=float(sigmoid_vec(alpha_self_shared_z[i] + alpha_self_delta_z[i])),
+            alpha_other_outcome=float(sigmoid_vec(aoo_shared_z[i] + aoo_delta_z[i])),
+            alpha_other_action=float(sigmoid_vec(aoa_shared_z[i] + aoa_delta_z[i])),
+            w_imitation=float(sigmoid_vec(wi_shared_z[i] + wi_delta_z[i])),
+            beta=float(softplus_vec(beta_shared_z[i] + beta_delta_z[i])),
+        ),
+    }
+
+# ── 4. Set up condition-aware layout ────────────────────────────────────────
+layout = SharedDeltaLayout(
+    kernel_spec=kernel.spec(),
+    conditions=("social_low", "social_high"),
+    baseline_condition="social_low",
+)
+
+print(f"Layout parameter keys: {layout.parameter_keys()}")
+
+# ── 5. Print ground-truth population parameters ─────────────────────────────
+print("\nGround-truth population parameters (baseline condition, constrained):")
+print(f"  alpha_self:          {float(sigmoid_vec(TRUE_MU_ALPHA_SELF_SHARED_Z)):.3f}")
+print(f"  alpha_other_outcome: {float(sigmoid_vec(TRUE_MU_ALPHA_OTHER_OUTCOME_SHARED_Z)):.3f}")
+print(f"  alpha_other_action:  {float(sigmoid_vec(TRUE_MU_ALPHA_OTHER_ACTION_SHARED_Z)):.3f}")
+print(f"  w_imitation:         {float(sigmoid_vec(TRUE_MU_W_IMITATION_SHARED_Z)):.3f}")
+print(f"  beta:                {float(softplus_vec(np.array(TRUE_MU_BETA_SHARED_Z))):.3f}")
+
+# ── 6. Simulate dataset ────────────────────────────────────────────────────
+subjects = []
+for i in range(N_SUBJECTS):
+    sid = f"sub_{i:02d}"
+    blocks = []
+    for block_idx, block_spec in enumerate(task.blocks):
+        condition = block_spec.condition
+        sub = simulate_subject(
+            task=TaskSpec(task_id="tmp", blocks=(block_spec,)),
+            env=StationaryBanditEnvironment(n_actions=N_ACTIONS, reward_probs=REWARD_PROBS),
+            kernel=kernel,
+            params=TRUE_PARAMS_PER_SUBJECT[sid][condition],
+            config=SimulationConfig(seed=42 + i * 1000 + block_idx),
+            subject_id=sid,
+            demonstrator_kernel=AsocialQLearningKernel(),
+            demonstrator_params=QParams(alpha=0.0, beta=0.0),
+        )
+        blocks.append(
+            Block(
+                block_index=block_idx,
+                condition=sub.blocks[0].condition,
+                trials=sub.blocks[0].trials,
+            )
+        )
+    subjects.append(SubjectData(subject_id=sid, blocks=tuple(blocks)))
+
+dataset = Dataset(subjects=tuple(subjects))
+
+# ── 7. Save to CSV ─────────────────────────────────────────────────────────
+csv_path = Path(__file__).parent / "hierarchical_within_subject_data.csv"
+save_dataset_to_csv(dataset, schema=SOCIAL_PRE_CHOICE_SCHEMA, path=csv_path)
+print(f"\nSaved {len(dataset.subjects)} subjects x {len(task.blocks)} blocks to {csv_path}")
+
+# ── 8. Fit with hierarchical condition-aware Stan ───────────────────────────
+stan_config = InferenceConfig(
+    hierarchy=HierarchyStructure.STUDY_SUBJECT_BLOCK_CONDITION,
+    backend="stan",
+    stan_config=StanFitConfig(n_warmup=500, n_samples=500, n_chains=4, seed=42),
+)
+
+adapter = SocialRlSelfRewardDemoMixtureStanAdapter()
+result = fit(stan_config, kernel, dataset, SOCIAL_PRE_CHOICE_SCHEMA, layout=layout, adapter=adapter)
+
+# ── 9. Report results ────────────────────────────────────────────────────────
+print(f"\nModel: {result.model_id}")
+print(f"Hierarchy: {result.hierarchy}")
+
+shared_pop_keys = [
+    ("alpha_self_shared_pop", "alpha_self", float(sigmoid_vec(TRUE_MU_ALPHA_SELF_SHARED_Z))),
+    (
+        "alpha_other_outcome_shared_pop",
+        "alpha_other_outcome",
+        float(sigmoid_vec(TRUE_MU_ALPHA_OTHER_OUTCOME_SHARED_Z)),
+    ),
+    (
+        "alpha_other_action_shared_pop",
+        "alpha_other_action",
+        float(sigmoid_vec(TRUE_MU_ALPHA_OTHER_ACTION_SHARED_Z)),
+    ),
+    ("w_imitation_shared_pop", "w_imitation", float(sigmoid_vec(TRUE_MU_W_IMITATION_SHARED_Z))),
+    ("beta_shared_pop", "beta", float(softplus_vec(np.array(TRUE_MU_BETA_SHARED_Z)))),
+]
+
+print("\nPopulation posterior means (baseline condition, constrained):")
+for pop_key, label, true_val in shared_pop_keys:
+    if pop_key in result.posterior_samples:
+        est = float(np.mean(result.posterior_samples[pop_key]))
+        print(f"  {label:<22}: {est:.3f}  (true: {true_val:.3f})")
+
+param_labels = [
+    "alpha_self",
+    "alpha_other_outcome",
+    "alpha_other_action",
+    "w_imitation",
+    "beta",
+]
+
+if all(p in result.posterior_samples for p in param_labels):
+    print(
+        f"\n{'Subject':<10} {'Cond':<14} "
+        + " ".join(f"{'True ' + p[:5]:>8} {'Post ' + p[:5]:>10}" for p in param_labels)
+    )
+    print("-" * (10 + 14 + 19 * len(param_labels)))
+    for i in range(N_SUBJECTS):
+        sid = f"sub_{i:02d}"
+        for c_idx, condition in enumerate(layout.conditions):
+            true_p = TRUE_PARAMS_PER_SUBJECT[sid][condition]
+            true_vals = [
+                true_p.alpha_self,
+                true_p.alpha_other_outcome,
+                true_p.alpha_other_action,
+                true_p.w_imitation,
+                true_p.beta,
+            ]
+            # shape: (n_draws, N_SUBJECTS, C)
+            post_vals = [
+                float(np.mean(result.posterior_samples[p][:, i, c_idx])) for p in param_labels
+            ]
+            row = f"{sid:<10} {condition:<14} "
+            row += " ".join(
+                f"{t:>8.3f} {po:>10.3f}" for t, po in zip(true_vals, post_vals, strict=True)
+            )
+            print(row)
+
+print("\nDone.")

--- a/example/social_rl_self_reward_demo_mixture/stan_no_pooling.py
+++ b/example/social_rl_self_reward_demo_mixture/stan_no_pooling.py
@@ -1,0 +1,127 @@
+"""Simulate mixture social RL agents and recover parameters with per-subject
+Bayesian Stan inference (no hierarchical pooling).
+
+Each subject is fit independently with weakly informative priors
+(SUBJECT_SHARED hierarchy). Useful when you do not want to assume subjects
+are drawn from a shared population distribution.
+
+Ground-truth: alpha_self=0.3, alpha_other_outcome=0.2, alpha_other_action=0.4,
+              w_imitation=0.3, beta=2.0 (same for all subjects)
+
+Requires: cmdstanpy and a working CmdStan installation.
+
+Usage:
+    uv run python example/social_rl_self_reward_demo_mixture/stan_no_pooling.py
+"""
+
+from pathlib import Path
+
+import numpy as np
+
+from comp_model.environments import StationaryBanditEnvironment
+from comp_model.inference import fit
+from comp_model.inference.bayes.stan import (
+    SocialRlSelfRewardDemoMixtureStanAdapter,
+    StanFitConfig,
+)
+from comp_model.inference.config import HierarchyStructure, InferenceConfig
+from comp_model.io import save_dataset_to_csv
+from comp_model.models.kernels import (
+    AsocialQLearningKernel,
+    QParams,
+    SocialRlSelfRewardDemoMixtureKernel,
+    SocialRlSelfRewardDemoMixtureParams,
+)
+from comp_model.runtime import SimulationConfig, simulate_dataset
+from comp_model.tasks import SOCIAL_PRE_CHOICE_SCHEMA, BlockSpec, TaskSpec
+
+# ── 1. Define task ──────────────────────────────────────────────────────────
+N_ACTIONS = 2
+N_TRIALS = 100
+N_SUBJECTS = 5
+REWARD_PROBS = (0.8, 0.2)
+
+task = TaskSpec(
+    task_id="social_pre_choice_mixture",
+    blocks=(
+        BlockSpec(
+            condition="social",
+            n_trials=N_TRIALS,
+            schema=SOCIAL_PRE_CHOICE_SCHEMA,
+            metadata={"n_actions": N_ACTIONS},
+        ),
+    ),
+)
+
+# ── 2. Ground-truth parameters ─────────────────────────────────────────────
+TRUE_ALPHA_SELF = 0.3
+TRUE_ALPHA_OTHER_OUTCOME = 0.2
+TRUE_ALPHA_OTHER_ACTION = 0.4
+TRUE_W_IMITATION = 0.3
+TRUE_BETA = 2.0
+
+kernel = SocialRlSelfRewardDemoMixtureKernel()
+true_params = SocialRlSelfRewardDemoMixtureParams(
+    alpha_self=TRUE_ALPHA_SELF,
+    alpha_other_outcome=TRUE_ALPHA_OTHER_OUTCOME,
+    alpha_other_action=TRUE_ALPHA_OTHER_ACTION,
+    w_imitation=TRUE_W_IMITATION,
+    beta=TRUE_BETA,
+)
+
+# ── 3. Simulate dataset ────────────────────────────────────────────────────
+params_per_subject = {f"sub_{i:02d}": true_params for i in range(N_SUBJECTS)}
+
+dataset = simulate_dataset(
+    task=task,
+    env_factory=lambda: StationaryBanditEnvironment(n_actions=N_ACTIONS, reward_probs=REWARD_PROBS),
+    kernel=kernel,
+    params_per_subject=params_per_subject,
+    config=SimulationConfig(seed=42),
+    demonstrator_kernel=AsocialQLearningKernel(),
+    demonstrator_params=QParams(alpha=0.0, beta=0.0),
+)
+
+# ── 4. Save to CSV ─────────────────────────────────────────────────────────
+csv_path = Path(__file__).parent / "data.csv"
+save_dataset_to_csv(dataset, schema=SOCIAL_PRE_CHOICE_SCHEMA, path=csv_path)
+print(f"Saved {len(dataset.subjects)} subjects to {csv_path}")
+
+# ── 5. Fit each subject independently with Stan ────────────────────────────
+stan_config = InferenceConfig(
+    hierarchy=HierarchyStructure.SUBJECT_SHARED,
+    backend="stan",
+    stan_config=StanFitConfig(n_warmup=500, n_samples=500, n_chains=4, seed=42),
+)
+
+adapter = SocialRlSelfRewardDemoMixtureStanAdapter()
+
+print(
+    f"\n{'Subject':<12} "
+    f"{'True as':>8} {'Post as':>10} "
+    f"{'True aoo':>9} {'Post aoo':>11} "
+    f"{'True aoa':>9} {'Post aoa':>11} "
+    f"{'True wi':>8} {'Post wi':>10} "
+    f"{'True b':>7} {'Post b':>9}"
+)
+print("-" * 110)
+
+for subject in dataset.subjects:
+    result = fit(stan_config, kernel, subject, SOCIAL_PRE_CHOICE_SCHEMA, adapter=adapter)
+    ps = result.posterior_samples
+    print(
+        f"{subject.subject_id:<12} "
+        f"{TRUE_ALPHA_SELF:>8.3f} {np.mean(ps['alpha_self']):>10.3f} "
+        f"{TRUE_ALPHA_OTHER_OUTCOME:>9.3f} {np.mean(ps['alpha_other_outcome']):>11.3f} "
+        f"{TRUE_ALPHA_OTHER_ACTION:>9.3f} {np.mean(ps['alpha_other_action']):>11.3f} "
+        f"{TRUE_W_IMITATION:>8.3f} {np.mean(ps['w_imitation']):>10.3f} "
+        f"{TRUE_BETA:>7.3f} {np.mean(ps['beta']):>9.3f}"
+    )
+
+print(
+    f"\nTrue values: alpha_self={TRUE_ALPHA_SELF}, "
+    f"alpha_other_outcome={TRUE_ALPHA_OTHER_OUTCOME}, "
+    f"alpha_other_action={TRUE_ALPHA_OTHER_ACTION}, "
+    f"w_imitation={TRUE_W_IMITATION}, beta={TRUE_BETA}"
+)
+print("Done.")

--- a/example/social_rl_self_reward_demo_mixture/stan_within_subject.py
+++ b/example/social_rl_self_reward_demo_mixture/stan_within_subject.py
@@ -1,0 +1,179 @@
+"""Simulate mixture social RL agents with two social conditions, then recover
+condition-specific parameters with Stan (NUTS) inference using SharedDeltaLayout.
+
+Within-subject design: each subject experiences both conditions. The model
+estimates a shared baseline parameter set plus additive deltas for the
+non-baseline condition on the unconstrained scale.
+
+Ground-truth:
+  Condition "social_low"  (baseline): alpha_self=0.3, alpha_other_outcome=0.1,
+                                       alpha_other_action=0.2, w_imitation=0.2, beta=2.0
+  Condition "social_high":             alpha_self=0.3, alpha_other_outcome=0.4,
+                                       alpha_other_action=0.6, w_imitation=0.5, beta=2.0
+
+Requires: cmdstanpy and a working CmdStan installation.
+
+Usage:
+    uv run python example/social_rl_self_reward_demo_mixture/stan_within_subject.py
+"""
+
+from pathlib import Path
+
+import numpy as np
+
+from comp_model.data import Block, Dataset, SubjectData
+from comp_model.environments import StationaryBanditEnvironment
+from comp_model.inference import fit
+from comp_model.inference.bayes.stan import (
+    SocialRlSelfRewardDemoMixtureStanAdapter,
+    StanFitConfig,
+)
+from comp_model.inference.config import HierarchyStructure, InferenceConfig
+from comp_model.io import save_dataset_to_csv
+from comp_model.models import SharedDeltaLayout
+from comp_model.models.kernels import (
+    AsocialQLearningKernel,
+    QParams,
+    SocialRlSelfRewardDemoMixtureKernel,
+    SocialRlSelfRewardDemoMixtureParams,
+)
+from comp_model.runtime import SimulationConfig, simulate_subject
+from comp_model.tasks import SOCIAL_PRE_CHOICE_SCHEMA, BlockSpec, TaskSpec
+
+# ── 1. Define task with two conditions ──────────────────────────────────────
+N_ACTIONS = 3
+N_TRIALS = 200
+N_SUBJECTS = 5
+REWARD_PROBS = (0.25, 0.5, 0.75)
+
+task = TaskSpec(
+    task_id="social_mixture_within",
+    blocks=(
+        BlockSpec(
+            condition="social_low",
+            n_trials=N_TRIALS,
+            schema=SOCIAL_PRE_CHOICE_SCHEMA,
+            metadata={"n_actions": N_ACTIONS},
+        ),
+        BlockSpec(
+            condition="social_high",
+            n_trials=N_TRIALS,
+            schema=SOCIAL_PRE_CHOICE_SCHEMA,
+            metadata={"n_actions": N_ACTIONS},
+        ),
+    ),
+)
+
+# ── 2. Ground-truth parameters per condition ────────────────────────────────
+TRUE_PARAMS = {
+    "social_low": SocialRlSelfRewardDemoMixtureParams(
+        alpha_self=0.3,
+        alpha_other_outcome=0.1,
+        alpha_other_action=0.2,
+        w_imitation=0.2,
+        beta=2.0,
+    ),
+    "social_high": SocialRlSelfRewardDemoMixtureParams(
+        alpha_self=0.3,
+        alpha_other_outcome=0.4,
+        alpha_other_action=0.6,
+        w_imitation=0.5,
+        beta=2.0,
+    ),
+}
+
+kernel = SocialRlSelfRewardDemoMixtureKernel()
+
+# ── 3. Set up condition-aware layout ────────────────────────────────────────
+layout = SharedDeltaLayout(
+    kernel_spec=kernel.spec(),
+    conditions=("social_low", "social_high"),
+    baseline_condition="social_low",
+)
+
+print(f"Layout parameter keys: {layout.parameter_keys()}")
+
+# ── 4. Simulate dataset ────────────────────────────────────────────────────
+subjects = []
+for i in range(N_SUBJECTS):
+    sid = f"sub_{i:02d}"
+    blocks = []
+    for block_idx, block_spec in enumerate(task.blocks):
+        condition = block_spec.condition
+        sub = simulate_subject(
+            task=TaskSpec(task_id="tmp", blocks=(block_spec,)),
+            env=StationaryBanditEnvironment(n_actions=N_ACTIONS, reward_probs=REWARD_PROBS),
+            kernel=kernel,
+            params=TRUE_PARAMS[condition],
+            config=SimulationConfig(seed=42 + i + block_idx * 100),
+            subject_id=sid,
+            demonstrator_kernel=AsocialQLearningKernel(),
+            demonstrator_params=QParams(alpha=0.3, beta=20.0),
+        )
+        blocks.append(
+            Block(
+                block_index=block_idx,
+                condition=sub.blocks[0].condition,
+                trials=sub.blocks[0].trials,
+            )
+        )
+    subjects.append(SubjectData(subject_id=sid, blocks=tuple(blocks)))
+
+dataset = Dataset(subjects=tuple(subjects))
+
+# ── 5. Save to CSV ─────────────────────────────────────────────────────────
+csv_path = Path(__file__).parent / "within_subject_data.csv"
+save_dataset_to_csv(dataset, schema=SOCIAL_PRE_CHOICE_SCHEMA, path=csv_path)
+print(f"Saved {len(dataset.subjects)} subjects x {len(task.blocks)} blocks to {csv_path}")
+
+# ── 6. Fit each subject with condition-aware Stan ───────────────────────────
+stan_config = InferenceConfig(
+    hierarchy=HierarchyStructure.SUBJECT_BLOCK_CONDITION,
+    backend="stan",
+    stan_config=StanFitConfig(n_warmup=500, n_samples=500, n_chains=4, seed=42),
+)
+
+adapter = SocialRlSelfRewardDemoMixtureStanAdapter()
+
+param_labels = [
+    "alpha_self",
+    "alpha_other_outcome",
+    "alpha_other_action",
+    "w_imitation",
+    "beta",
+]
+
+print(
+    f"\n{'Subject':<10} {'Cond':<14} "
+    + " ".join(f"{'True ' + p[:5]:>8} {'Post ' + p[:5]:>10}" for p in param_labels)
+)
+print("-" * (10 + 14 + 19 * len(param_labels)))
+
+for subject in dataset.subjects:
+    result = fit(
+        stan_config,
+        kernel,
+        subject,
+        SOCIAL_PRE_CHOICE_SCHEMA,
+        layout=layout,
+        adapter=adapter,
+    )
+
+    # Each param is shape (n_draws, C) for SUBJECT_BLOCK_CONDITION
+    for c_idx, condition in enumerate(layout.conditions):
+        true_p = TRUE_PARAMS[condition]
+        true_vals = [
+            true_p.alpha_self,
+            true_p.alpha_other_outcome,
+            true_p.alpha_other_action,
+            true_p.w_imitation,
+            true_p.beta,
+        ]
+        post_vals = [float(np.mean(result.posterior_samples[p][:, c_idx])) for p in param_labels]
+        row = f"{subject.subject_id:<10} {condition:<14} "
+        row += " ".join(
+            f"{t:>8.3f} {po:>10.3f}" for t, po in zip(true_vals, post_vals, strict=True)
+        )
+        print(row)
+
+print("\nDone.")


### PR DESCRIPTION
## Summary

Completes the mixture model example suite to match `asocial_rl` (12 scripts total):

- `mle_within_subject.py` — per-subject MLE with `SharedDeltaLayout` (`SUBJECT_BLOCK_CONDITION`)
- `stan_no_pooling.py` — per-subject Stan, no hierarchical pooling (`SUBJECT_SHARED`)
- `stan_within_subject.py` — per-subject Stan with `SharedDeltaLayout` (`SUBJECT_BLOCK_CONDITION`)
- `stan_hierarchical_within_subject.py` — hierarchical Stan with `SharedDeltaLayout` (`STUDY_SUBJECT_BLOCK_CONDITION`)
- `check_block_recovery.py` — MLE recovery quality vs number of blocks

Two-condition within-subject design: `social_low` (baseline) vs `social_high`, differing in `alpha_other_outcome`, `alpha_other_action`, and `w_imitation`.

## Test plan

- [ ] `uv run python example/social_rl_self_reward_demo_mixture/mle_within_subject.py` ✅ verified
- [ ] `uv run python example/social_rl_self_reward_demo_mixture/check_block_recovery.py` ✅ verified
- [ ] Stan data pipeline for `SUBJECT_BLOCK_CONDITION` and `STUDY_SUBJECT_BLOCK_CONDITION` ✅ verified
- [ ] `uv run pytest -x -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)