### PR TITLE
refactor(mixture/recovery): per-condition independent Stan recovery

### DIFF
--- a/example/social_rl_self_reward_demo_mixture/stan_hierarchical_within_subject_recovery.py
+++ b/example/social_rl_self_reward_demo_mixture/stan_hierarchical_within_subject_recovery.py
@@ -4,9 +4,9 @@ Two demonstrator conditions per subject:
   "strong_demo": demonstrator alpha=0.3, beta=20.0
   "weak_demo":   demonstrator alpha=0.3, beta=1.5
 
-Two blocks per condition (4 blocks total), 60 trials per block, 64 subjects.
-Subject parameters are sampled from uniform distributions via SharedDeltaLayout.
-Fit with STUDY_SUBJECT_BLOCK_CONDITION hierarchy.
+Two blocks per condition, 60 trials per block, 64 subjects.
+Parameters are sampled uniformly on the unconstrained scale.
+Each condition is fit independently with STUDY_SUBJECT hierarchy.
 
 Usage:
     uv run python \
@@ -21,7 +21,6 @@ from comp_model.inference.bayes.stan import (
     StanFitConfig,
 )
 from comp_model.inference.config import HierarchyStructure, InferenceConfig
-from comp_model.models import SharedDeltaLayout
 from comp_model.models.kernels import (
     AsocialQLearningKernel,
     QParams,
@@ -37,86 +36,81 @@ from comp_model.recovery import (
 )
 from comp_model.tasks import SOCIAL_PRE_CHOICE_SCHEMA, BlockSpec, TaskSpec
 
+N_ACTIONS = 2
+N_TRIALS_PER_BLOCK = 60
+N_BLOCKS_PER_CONDITION = 2
+N_SUBJECTS = 64
+REWARD_PROBS = (0.8, 0.2)
+
+# Uniform on unconstrained scale:
+#   sigmoid(-3, 3) → constrained (0.047, 0.953) for alpha params
+#   softplus(-1, 5) → constrained (0.31, 5.0)   for beta
+PARAM_DISTS = (
+    ParamDist("alpha_self", stats.uniform(-3, 6), scale="unconstrained"),
+    ParamDist("alpha_other_outcome", stats.uniform(-3, 6), scale="unconstrained"),
+    ParamDist("alpha_other_action", stats.uniform(-3, 6), scale="unconstrained"),
+    ParamDist("w_imitation", stats.uniform(-3, 6), scale="unconstrained"),
+    ParamDist("beta", stats.uniform(-1, 6), scale="unconstrained"),
+)
+
+STAN_CONFIG = InferenceConfig(
+    hierarchy=HierarchyStructure.STUDY_SUBJECT,
+    backend="stan",
+    stan_config=StanFitConfig(n_warmup=500, n_samples=500, n_chains=4, seed=42),
+)
+
 
 def main() -> None:
-    """Run hierarchical within-subject Stan recovery for the mixture social RL kernel."""
-    N_ACTIONS = 2
-    N_TRIALS_PER_BLOCK = 60
-    N_BLOCKS_PER_CONDITION = 2
-    N_SUBJECTS = 64
-    REWARD_PROBS = (0.8, 0.2)
-    CONDITIONS = ("strong_demo", "weak_demo")
-
-    task = TaskSpec(
-        task_id="recovery_within_subject_mixture",
-        blocks=tuple(
-            BlockSpec(
-                condition=condition,
-                n_trials=N_TRIALS_PER_BLOCK,
-                schema=SOCIAL_PRE_CHOICE_SCHEMA,
-                metadata={"n_actions": N_ACTIONS},
-            )
-            for condition in CONDITIONS
-            for _ in range(N_BLOCKS_PER_CONDITION)
-        ),
-    )
-
+    """Run per-condition hierarchical Stan recovery for the mixture social RL kernel."""
     kernel = SocialRlSelfRewardDemoMixtureKernel()
-    layout = SharedDeltaLayout(
-        kernel_spec=kernel.spec(),
-        conditions=CONDITIONS,
-        baseline_condition="strong_demo",
-    )
+    adapter = SocialRlSelfRewardDemoMixtureStanAdapter()
 
-    # Shared (baseline): uniform on constrained scale.
-    # Delta (weak_demo - strong_demo): normal on unconstrained scale.
-    param_dists = (
-        ParamDist("alpha_self", stats.uniform(0, 1), scale="constrained"),
-        ParamDist("alpha_other_outcome", stats.uniform(0, 1), scale="constrained"),
-        ParamDist("alpha_other_action", stats.uniform(0, 1), scale="constrained"),
-        ParamDist("w_imitation", stats.uniform(0, 1), scale="constrained"),
-        ParamDist("beta", stats.uniform(0.5, 4.5), scale="constrained"),
-        ParamDist("alpha_self__delta", stats.norm(0, 0.5), scale="unconstrained"),
-        ParamDist("alpha_other_outcome__delta", stats.norm(0, 0.5), scale="unconstrained"),
-        ParamDist("alpha_other_action__delta", stats.norm(0, 0.5), scale="unconstrained"),
-        ParamDist("w_imitation__delta", stats.norm(0, 0.5), scale="unconstrained"),
-        ParamDist("beta__delta", stats.norm(0, 0.3), scale="unconstrained"),
-    )
+    for condition, demo_params in (
+        ("strong_demo", QParams(alpha=0.3, beta=20.0)),
+        ("weak_demo", QParams(alpha=0.3, beta=1.5)),
+    ):
+        task = TaskSpec(
+            task_id=f"recovery_{condition}",
+            blocks=tuple(
+                BlockSpec(
+                    condition=condition,
+                    n_trials=N_TRIALS_PER_BLOCK,
+                    schema=SOCIAL_PRE_CHOICE_SCHEMA,
+                    metadata={"n_actions": N_ACTIONS},
+                )
+                for _ in range(N_BLOCKS_PER_CONDITION)
+            ),
+        )
 
-    config = RecoveryStudyConfig(
-        n_replications=1,
-        n_subjects=N_SUBJECTS,
-        param_dists=param_dists,
-        task=task,
-        env_factory=lambda: StationaryBanditEnvironment(
-            n_actions=N_ACTIONS, reward_probs=REWARD_PROBS
-        ),
-        kernel=kernel,
-        schema=SOCIAL_PRE_CHOICE_SCHEMA,
-        layout=layout,
-        demonstrator_kernel=AsocialQLearningKernel(),
-        condition_demonstrator_params={
-            "strong_demo": QParams(alpha=0.3, beta=20.0),
-            "weak_demo": QParams(alpha=0.3, beta=1.5),
-        },
-        inference_config=InferenceConfig(
-            hierarchy=HierarchyStructure.STUDY_SUBJECT_BLOCK_CONDITION,
-            backend="stan",
-            stan_config=StanFitConfig(n_warmup=500, n_samples=500, n_chains=4, seed=42),
-        ),
-        adapter=SocialRlSelfRewardDemoMixtureStanAdapter(),
-        simulation_base_seed=42,
-    )
+        config = RecoveryStudyConfig(
+            n_replications=1,
+            n_subjects=N_SUBJECTS,
+            param_dists=PARAM_DISTS,
+            task=task,
+            env_factory=lambda: StationaryBanditEnvironment(
+                n_actions=N_ACTIONS, reward_probs=REWARD_PROBS
+            ),
+            kernel=kernel,
+            schema=SOCIAL_PRE_CHOICE_SCHEMA,
+            demonstrator_kernel=AsocialQLearningKernel(),
+            demonstrator_params=demo_params,
+            inference_config=STAN_CONFIG,
+            adapter=adapter,
+            simulation_base_seed=42,
+        )
 
-    print(f"Running {config.n_replications} rep x {config.n_subjects} subjects...")
-    result = run_recovery(config)
+        print(f"\n{'=' * 60}")
+        print(f"Condition: {condition}  (demonstrator beta={demo_params.beta})")
+        print(f"Running {config.n_replications} rep x {config.n_subjects} subjects...")
+        result = run_recovery(config)
 
-    print("\nPer-subject true vs posterior mean:")
-    print(recovery_summary(result))
+        print("\nPer-subject true vs posterior mean:")
+        print(recovery_summary(result))
 
-    metrics = compute_recovery_metrics(result)
-    print("\nRecovery metrics (STUDY_SUBJECT_BLOCK_CONDITION Stan):")
-    print(recovery_table(metrics))
+        metrics = compute_recovery_metrics(result)
+        print("\nRecovery metrics:")
+        print(recovery_table(metrics))
+
     print("\nDone.")
 
 


### PR DESCRIPTION
## Summary

- Rewrites `stan_hierarchical_within_subject_recovery.py` to loop over each condition independently using `STUDY_SUBJECT` hierarchy — no `SharedDeltaLayout`, no delta params
- All 5 parameters sampled uniformly on the unconstrained scale (`sigmoid(-3,3)` → constrained `(0.047, 0.953)` for alphas; `softplus(-1,5)` → `(0.31, 5.0)` for beta)
- One `RecoveryStudyConfig` + `run_recovery` call per condition, with condition-specific demonstrator params (`strong_demo` β=20, `weak_demo` β=1.5)

## Test plan

- [ ] `uv run python example/social_rl_self_reward_demo_mixture/stan_hierarchical_within_subject_recovery.py` — runs end-to-end and prints per-condition recovery tables
- [ ] `uv run ruff check` and `uv run ruff format --check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)