### PR TITLE
fix: keep population recovery outputs on constrained scale

### DIFF
--- a/src/comp_model/recovery/parameter/extraction.py
+++ b/src/comp_model/recovery/parameter/extraction.py
@@ -195,13 +195,11 @@ def extract_population_records(
     true_pop: dict[str, float],
     layout: SharedDeltaLayout | None = None,
 ) -> tuple[PopulationRecord, ...]:
-    """Extract population records from a hierarchical Bayes fit.
+    """Extract constrained-scale population records from a hierarchical Bayes fit.
 
-    Iterates over the keys in *true_pop* and extracts a record for every
-    key that also exists in the posterior samples.  This approach is
-    naming-convention agnostic and works for both simple hierarchies
-    (``alpha_pop``, ``mu_alpha_z``) and condition-aware hierarchies
-    (``alpha_shared_pop``, ``mu_alpha_shared_z``, ``sd_alpha_delta_z``).
+    Iterates over the constrained-scale keys in *true_pop* and extracts a
+    record for every key that also exists in the posterior samples. Only
+    population mean outputs whose names end with ``"_pop"`` are reported.
 
     Parameters
     ----------
@@ -209,8 +207,7 @@ def extract_population_records(
         Bayesian fit result with posterior samples.
     true_pop
         True population parameter values keyed by the same names that appear
-        in the posterior (e.g. ``alpha_pop``, ``mu_alpha_z``,
-        ``mu_alpha_shared_z``).
+        in the posterior (e.g. ``alpha_pop``, ``alpha_shared_pop``).
     layout
         Optional condition-aware layout used to split vector-valued
         population delta parameters into one record per non-baseline
@@ -236,6 +233,8 @@ def extract_population_records(
         )
 
     for key, true_val in true_pop.items():
+        if not key.endswith("_pop"):
+            continue
         if key in result.posterior_samples:
             draws = np.asarray(result.posterior_samples[key])
             if draws.ndim == 0:

--- a/src/comp_model/recovery/parameter/runner.py
+++ b/src/comp_model/recovery/parameter/runner.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 from comp_model.data.schema import Block, Dataset, SubjectData
 from comp_model.inference.bayes.result import BayesFitResult
 from comp_model.inference.dispatch import fit
-from comp_model.recovery.parameter.config import get_true_population_params, sample_true_params
+from comp_model.recovery.parameter.config import sample_true_params
 from comp_model.recovery.parameter.extraction import (
     extract_bayes_subject_records,
     extract_mle_subject_records,
@@ -62,7 +62,7 @@ def _build_true_population_values(
     true_table: dict[str, dict[str, float]],
     param_names: tuple[str, ...],
 ) -> dict[str, float]:
-    """Build true population values aligned with Stan posterior naming.
+    """Build constrained-scale population truths for recovery summaries.
 
     Parameters
     ----------
@@ -76,25 +76,15 @@ def _build_true_population_values(
     Returns
     -------
     dict[str, float]
-        True population values keyed to the names emitted by the Stan
-        adapter for the configured hierarchy.
+        True constrained-scale population values keyed to the constrained
+        population outputs emitted by Stan.
 
     Notes
     -----
-    For simple hierarchies this returns the empirical constrained-scale
-    population means (``{name}_pop``) plus any unconstrained-scale
-    ``mu_{name}_z`` / ``sd_{name}_z`` values available from
-    ``ParamDist(scale="unconstrained")``.
+    Population-level recovery reports only constrained-scale means:
 
-    For condition-aware hierarchies this returns:
-
-    - empirical baseline-condition constrained means as
-      ``{name}_shared_pop``, and
-    - unconstrained-scale shared and delta distribution moments as
-      ``mu_{name}_shared_z``, ``sd_{name}_shared_z``,
-      ``mu_{name}_delta_z``, and ``sd_{name}_delta_z`` when the
-      corresponding ``ParamDist`` entries were specified on the
-      unconstrained scale.
+    - ``{name}_pop`` for simple hierarchies
+    - ``{name}_shared_pop`` for condition-aware hierarchies
     """
 
     if config.layout is None:
@@ -103,12 +93,10 @@ def _build_true_population_values(
             vals = [true_table[sid][name] for sid in true_table if name in true_table[sid]]
             if vals:
                 true_pop[f"{name}_pop"] = float(np.mean(vals))
-        true_pop.update(get_true_population_params(config.param_dists, config.kernel))
         return true_pop
 
     true_pop = {}
     baseline_condition = config.layout.baseline_condition
-    dist_by_name = {dist.name: dist for dist in config.param_dists}
 
     for name in param_names:
         baseline_key = f"{name}__{baseline_condition}"
@@ -117,16 +105,6 @@ def _build_true_population_values(
         ]
         if vals:
             true_pop[f"{name}_shared_pop"] = float(np.mean(vals))
-
-        shared_dist = dist_by_name.get(name)
-        if shared_dist is not None and shared_dist.scale == "unconstrained":
-            true_pop[f"mu_{name}_shared_z"] = float(shared_dist.dist.mean())
-            true_pop[f"sd_{name}_shared_z"] = float(shared_dist.dist.std())
-
-        delta_dist = dist_by_name.get(f"{name}__delta")
-        if delta_dist is not None and delta_dist.scale == "unconstrained":
-            true_pop[f"mu_{name}_delta_z"] = float(delta_dist.dist.mean())
-            true_pop[f"sd_{name}_delta_z"] = float(delta_dist.dist.std())
 
     return true_pop
 

--- a/tests/test_recovery/test_extraction.py
+++ b/tests/test_recovery/test_extraction.py
@@ -314,8 +314,8 @@ class TestExtractPopulationRecords:
         assert records[0].estimated_value == pytest.approx(float(np.mean(posterior["alpha_pop"])))
         assert records[0].posterior_draws is not None
 
-    def test_unconstrained_keys(self) -> None:
-        """Unconstrained-scale mu/sd keys are extracted."""
+    def test_unconstrained_keys_are_skipped(self) -> None:
+        """Unconstrained-scale mu/sd keys are not reported."""
         rng = np.random.default_rng(11)
         n_draws = 100
         posterior = {
@@ -328,9 +328,7 @@ class TestExtractPopulationRecords:
 
         records = extract_population_records(result, true_pop)
 
-        assert len(records) == 2
-        names = {r.param_name for r in records}
-        assert names == {"mu_alpha_z", "sd_alpha_z"}
+        assert len(records) == 0
 
     def test_missing_true_pop_skipped(self) -> None:
         """Keys present in posterior but missing from true_pop are skipped."""
@@ -347,8 +345,8 @@ class TestExtractPopulationRecords:
 
         assert len(records) == 0
 
-    def test_condition_aware_keys(self) -> None:
-        """Condition-aware scalar population keys are extracted."""
+    def test_condition_aware_keys_only_keep_constrained_scale(self) -> None:
+        """Condition-aware population extraction keeps only constrained means."""
         rng = np.random.default_rng(13)
         n_draws = 100
         posterior = {
@@ -365,12 +363,12 @@ class TestExtractPopulationRecords:
 
         records = extract_population_records(result, true_pop)
 
-        assert len(records) == 3
+        assert len(records) == 1
         names = {r.param_name for r in records}
-        assert names == {"alpha_shared_pop", "mu_alpha_shared_z", "sd_alpha_shared_z"}
+        assert names == {"alpha_shared_pop"}
 
-    def test_condition_aware_vector_delta_keys(self) -> None:
-        """Vector-valued delta population keys are split by condition."""
+    def test_condition_aware_vector_delta_keys_are_skipped(self) -> None:
+        """Vector-valued unconstrained delta keys are not reported."""
         from comp_model.models.condition.shared_delta import SharedDeltaLayout
         from comp_model.models.kernels import AsocialQLearningKernel
 
@@ -396,33 +394,4 @@ class TestExtractPopulationRecords:
 
         records = extract_population_records(result, true_pop, layout=layout)
 
-        keyed = {(record.param_name, record.condition): record for record in records}
-        assert set(keyed) == {
-            ("mu_alpha_delta_z", "social"),
-            ("mu_alpha_delta_z", "transfer"),
-            ("sd_alpha_delta_z", "social"),
-            ("sd_alpha_delta_z", "transfer"),
-        }
-        assert keyed[("mu_alpha_delta_z", "social")].posterior_draws is not None
-        np.testing.assert_array_equal(
-            keyed[("mu_alpha_delta_z", "social")].posterior_draws,
-            posterior["mu_alpha_delta_z"][:, 0],
-        )
-        np.testing.assert_array_equal(
-            keyed[("mu_alpha_delta_z", "transfer")].posterior_draws,
-            posterior["mu_alpha_delta_z"][:, 1],
-        )
-
-    def test_vector_population_keys_require_layout(self) -> None:
-        """Vector-valued population keys require a condition-aware layout."""
-        posterior = {
-            "mu_alpha_delta_z": np.ones((10, 2)),
-        }
-        result = _make_bayes_result(
-            posterior,
-            HierarchyStructure.STUDY_SUBJECT_BLOCK_CONDITION,
-        )
-        true_pop = {"mu_alpha_delta_z": 0.0}
-
-        with pytest.raises(ValueError, match="must be scalar or condition-indexed"):
-            extract_population_records(result, true_pop)
+        assert records == ()

--- a/tests/test_recovery/test_parameter_runner.py
+++ b/tests/test_recovery/test_parameter_runner.py
@@ -223,22 +223,6 @@ class TestRunParameterRecovery:
         assert set(records) == {
             ("alpha_shared_pop", None),
             ("beta_shared_pop", None),
-            ("mu_alpha_shared_z", None),
-            ("sd_alpha_shared_z", None),
-            ("mu_beta_shared_z", None),
-            ("sd_beta_shared_z", None),
-            ("mu_alpha_delta_z", "social"),
-            ("sd_alpha_delta_z", "social"),
-            ("mu_beta_delta_z", "social"),
-            ("sd_beta_delta_z", "social"),
         }
         assert records[("alpha_shared_pop", None)].true_value == pytest.approx(0.45)
         assert records[("beta_shared_pop", None)].true_value == pytest.approx(1.25)
-        assert records[("mu_alpha_shared_z", None)].true_value == pytest.approx(0.1)
-        assert records[("sd_alpha_shared_z", None)].true_value == pytest.approx(0.2)
-        assert records[("mu_beta_shared_z", None)].true_value == pytest.approx(1.0)
-        assert records[("sd_beta_shared_z", None)].true_value == pytest.approx(0.3)
-        assert records[("mu_alpha_delta_z", "social")].true_value == pytest.approx(-0.4)
-        assert records[("sd_alpha_delta_z", "social")].true_value == pytest.approx(0.1)
-        assert records[("mu_beta_delta_z", "social")].true_value == pytest.approx(0.5)
-        assert records[("sd_beta_delta_z", "social")].true_value == pytest.approx(0.2)


### PR DESCRIPTION
## Summary
- limit population recovery extraction to constrained-scale population means (`*_pop`)
- stop building unconstrained `mu_*_z` and `sd_*_z` truth rows in the Stan recovery runner
- update recovery tests so population metrics only cover constrained-scale outputs

## Testing
- `uv run pytest tests/test_recovery/test_extraction.py tests/test_recovery/test_parameter_runner.py tests/test_recovery/test_metrics.py`
- `make check`