### PR TITLE
feat(recovery): condition-aware population records

### DIFF
--- a/src/comp_model/recovery/parameter/extraction.py
+++ b/src/comp_model/recovery/parameter/extraction.py
@@ -226,64 +226,70 @@ def extract_population_records(
         condition-aware layout is available to interpret it.
     """
     records: list[PopulationRecord] = []
-    nonbaseline_conditions = ()
+    nonbaseline_conditions: tuple[str, ...] = ()
     if layout is not None:
         nonbaseline_conditions = tuple(
-            condition for condition in layout.conditions if condition != layout.baseline_condition
+            condition
+            for condition in layout.conditions
+            if condition != layout.baseline_condition
         )
 
     for key, true_val in true_pop.items():
         if not key.endswith("_pop"):
             continue
-        if key in result.posterior_samples:
-            draws = np.asarray(result.posterior_samples[key])
-            if draws.ndim == 0:
-                scalar_draws = draws.reshape(1)
-                records.append(
-                    PopulationRecord(
-                        param_name=key,
-                        condition=None,
-                        true_value=true_val,
-                        estimated_value=float(np.mean(scalar_draws)),
-                        posterior_draws=scalar_draws,
-                    )
+        if key not in result.posterior_samples:
+            continue
+
+        draws = np.asarray(result.posterior_samples[key])
+
+        if draws.ndim == 0:
+            scalar_draws = draws.reshape(1)
+            records.append(
+                PopulationRecord(
+                    param_name=key,
+                    condition=None,
+                    true_value=true_val,
+                    estimated_value=float(np.mean(scalar_draws)),
+                    posterior_draws=scalar_draws,
                 )
-                continue
-
-            if draws.ndim == 1:
-                records.append(
-                    PopulationRecord(
-                        param_name=key,
-                        condition=None,
-                        true_value=true_val,
-                        estimated_value=float(np.mean(draws)),
-                        posterior_draws=draws,
-                    )
-                )
-                continue
-
-            if draws.ndim == 2 and layout is not None:
-                if draws.shape[1] != len(nonbaseline_conditions):
-                    raise ValueError(
-                        f"Population posterior {key!r} has shape {draws.shape}, "
-                        f"but layout expects {len(nonbaseline_conditions)} "
-                        "non-baseline conditions"
-                    )
-                for c_idx, condition in enumerate(nonbaseline_conditions):
-                    condition_draws = draws[:, c_idx]
-                    records.append(
-                        PopulationRecord(
-                            param_name=key,
-                            condition=condition,
-                            true_value=true_val,
-                            estimated_value=float(np.mean(condition_draws)),
-                            posterior_draws=condition_draws,
-                        )
-                    )
-                continue
-
-            raise ValueError(
-                f"Population posterior {key!r} must be scalar or condition-indexed; "
-                f"got shape {draws.shape}"
             )
+            continue
+
+        if draws.ndim == 1:
+            records.append(
+                PopulationRecord(
+                    param_name=key,
+                    condition=None,
+                    true_value=true_val,
+                    estimated_value=float(np.mean(draws)),
+                    posterior_draws=draws,
+                )
+            )
+            continue
+
+        if draws.ndim == 2 and layout is not None:
+            if draws.shape[1] != len(nonbaseline_conditions):
+                raise ValueError(
+                    f"Population posterior {key!r} has shape {draws.shape}, "
+                    f"but layout expects {len(nonbaseline_conditions)} "
+                    "non-baseline conditions"
+                )
+            for c_idx, condition in enumerate(nonbaseline_conditions):
+                condition_draws = draws[:, c_idx]
+                records.append(
+                    PopulationRecord(
+                        param_name=key,
+                        condition=condition,
+                        true_value=true_val,
+                        estimated_value=float(np.mean(condition_draws)),
+                        posterior_draws=condition_draws,
+                    )
+                )
+            continue
+
+        raise ValueError(
+            f"Population posterior {key!r} must be scalar or condition-indexed; "
+            f"got shape {draws.shape}"
+        )
+
     return tuple(records)

--- a/src/comp_model/recovery/parameter/runner.py
+++ b/src/comp_model/recovery/parameter/runner.py
@@ -284,6 +284,7 @@ def _run_stan_recovery(config: ParameterRecoveryConfig) -> ParameterRecoveryResu
             true_table,
             config.layout,  # type: ignore[arg-type]
         )
+
         true_pop = _build_true_population_values(config, true_table, param_names)
         pop_records = extract_population_records(result, true_pop, config.layout)
 

--- a/tests/test_recovery/test_parameter_runner.py
+++ b/tests/test_recovery/test_parameter_runner.py
@@ -137,8 +137,6 @@ class TestRunParameterRecovery:
             tuple[dict[str, dict[str, float]], dict[str, object]]
                 Fixed true-table and dummy parsed parameters.
             """
-
-            del args, kwargs
             return true_table, {}
 
         def _fake_simulate_dataset(
@@ -162,7 +160,6 @@ class TestRunParameterRecovery:
             Dataset
                 Empty dataset placeholder for the mocked fit.
             """
-
             del cfg, params_per_subject, seed
             return Dataset(subjects=())
 
@@ -181,7 +178,6 @@ class TestRunParameterRecovery:
             BayesFitResult
                 Mock posterior samples with condition-aware population keys.
             """
-
             del args, kwargs
             n_draws = 8
             posterior = {


### PR DESCRIPTION
## Summary
- Add `condition` field to `PopulationRecord` so vector-valued Stan delta posteriors (`n_draws × C-1`) are split into one record per non-baseline condition
- Update CSV export, metrics, and plotting to use condition-qualified keys (`param__condition`)
- Previously only shared (baseline) population params were displayed; now all condition-specific deltas appear individually

## Test plan
- [x] `test_condition_aware_vector_delta_keys` — verifies 2D delta posteriors split correctly by condition
- [x] `test_vector_population_keys_require_layout` — verifies `ValueError` when layout is missing for vector params
- [x] `test_population_condition_keys_are_scored_without_hdi_crashes` — verifies metrics compute safely with condition-qualified keys
- [x] `test_condition_aware_stan_pop_records_are_emitted` — end-to-end runner test with `(param_name, condition)` keyed assertions
- [x] All 15 recovery tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)