### PR TITLE
Re-apply PR #62: split condition-aware population delta recovery metrics

### DIFF
--- a/src/comp_model/recovery/parameter/extraction.py
+++ b/src/comp_model/recovery/parameter/extraction.py
@@ -193,14 +193,13 @@ def extract_bayes_subject_records(
 def extract_population_records(
     result: BayesFitResult,
     true_pop: dict[str, float],
+    layout: SharedDeltaLayout | None = None,
 ) -> tuple[PopulationRecord, ...]:
-    """Extract population records from a hierarchical Bayes fit.
+    """Extract constrained-scale population records from a hierarchical Bayes fit.
 
-    Iterates over the keys in *true_pop* and extracts a record for every
-    key that also exists in the posterior samples.  This approach is
-    naming-convention agnostic and works for both simple hierarchies
-    (``alpha_pop``, ``mu_alpha_z``) and condition-aware hierarchies
-    (``alpha_shared_pop``, ``mu_alpha_shared_z``, ``sd_alpha_delta_z``).
+    Iterates over the constrained-scale keys in *true_pop* and extracts a
+    record for every key that also exists in the posterior samples. Only
+    population mean outputs whose names end with ``"_pop"`` are reported.
 
     Parameters
     ----------
@@ -208,25 +207,83 @@ def extract_population_records(
         Bayesian fit result with posterior samples.
     true_pop
         True population parameter values keyed by the same names that appear
-        in the posterior (e.g. ``alpha_pop``, ``mu_alpha_z``,
-        ``mu_alpha_shared_z``).
+        in the posterior (e.g. ``alpha_pop``, ``alpha_shared_pop``).
+    layout
+        Optional condition-aware layout used to split vector-valued
+        population delta parameters into one record per non-baseline
+        condition.
 
     Returns
     -------
     tuple[PopulationRecord, ...]
         One record per population parameter found in both *true_pop* and
         the posterior.
+
+    Raises
+    ------
+    ValueError
+        If a posterior population parameter is not scalar and no
+        condition-aware layout is available to interpret it.
     """
     records: list[PopulationRecord] = []
+    nonbaseline_conditions = ()
+    if layout is not None:
+        nonbaseline_conditions = tuple(
+            condition for condition in layout.conditions if condition != layout.baseline_condition
+        )
+
     for key, true_val in true_pop.items():
+        if not key.endswith("_pop"):
+            continue
         if key in result.posterior_samples:
-            draws = result.posterior_samples[key]
-            records.append(
-                PopulationRecord(
-                    param_name=key,
-                    true_value=true_val,
-                    estimated_value=float(np.mean(draws)),
-                    posterior_draws=draws,
+            draws = np.asarray(result.posterior_samples[key])
+            if draws.ndim == 0:
+                scalar_draws = draws.reshape(1)
+                records.append(
+                    PopulationRecord(
+                        param_name=key,
+                        condition=None,
+                        true_value=true_val,
+                        estimated_value=float(np.mean(scalar_draws)),
+                        posterior_draws=scalar_draws,
+                    )
                 )
+                continue
+
+            if draws.ndim == 1:
+                records.append(
+                    PopulationRecord(
+                        param_name=key,
+                        condition=None,
+                        true_value=true_val,
+                        estimated_value=float(np.mean(draws)),
+                        posterior_draws=draws,
+                    )
+                )
+                continue
+
+            if draws.ndim == 2 and layout is not None:
+                if draws.shape[1] != len(nonbaseline_conditions):
+                    raise ValueError(
+                        f"Population posterior {key!r} has shape {draws.shape}, "
+                        f"but layout expects {len(nonbaseline_conditions)} "
+                        "non-baseline conditions"
+                    )
+                for c_idx, condition in enumerate(nonbaseline_conditions):
+                    condition_draws = draws[:, c_idx]
+                    records.append(
+                        PopulationRecord(
+                            param_name=key,
+                            condition=condition,
+                            true_value=true_val,
+                            estimated_value=float(np.mean(condition_draws)),
+                            posterior_draws=condition_draws,
+                        )
+                    )
+                continue
+
+            raise ValueError(
+                f"Population posterior {key!r} must be scalar or condition-indexed; "
+                f"got shape {draws.shape}"
             )
     return tuple(records)

--- a/src/comp_model/recovery/parameter/io.py
+++ b/src/comp_model/recovery/parameter/io.py
@@ -60,8 +60,8 @@ def save_subject_csv(result: ParameterRecoveryResult, path: Path) -> None:
 def save_population_csv(result: ParameterRecoveryResult, path: Path) -> None:
     """Write population-level recovery data to a CSV file.
 
-    Each row contains one (replication, parameter) data point with the
-    true and estimated population-level values.
+    Each row contains one (replication, parameter, condition) data point
+    with the true and estimated population-level values.
 
     Parameters
     ----------
@@ -72,9 +72,10 @@ def save_population_csv(result: ParameterRecoveryResult, path: Path) -> None:
 
     Notes
     -----
-    Columns: ``replication``, ``param_name``, ``true_value``,
-    ``estimated_value``.  Only replications with population-level results
-    are included.
+    Columns: ``replication``, ``param_name``, ``condition``,
+    ``true_value``, ``estimated_value``.  The ``condition`` column is
+    empty for non-condition-aware population parameters. Only replications
+    with population-level results are included.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", newline="") as f:
@@ -83,6 +84,7 @@ def save_population_csv(result: ParameterRecoveryResult, path: Path) -> None:
             [
                 "replication",
                 "param_name",
+                "condition",
                 "true_value",
                 "estimated_value",
             ]
@@ -95,6 +97,7 @@ def save_population_csv(result: ParameterRecoveryResult, path: Path) -> None:
                     [
                         replication.replication_index,
                         record.param_name,
+                        record.condition or "",
                         f"{record.true_value:.6f}",
                         f"{record.estimated_value:.6f}",
                     ]

--- a/src/comp_model/recovery/parameter/metrics.py
+++ b/src/comp_model/recovery/parameter/metrics.py
@@ -102,11 +102,14 @@ def compute_parameter_recovery_metrics(
         # Population-level pairs
         if replication.population_level is not None:
             for record in replication.population_level.records:
-                pairs.setdefault(record.param_name, []).append(
-                    (record.true_value, record.estimated_value)
+                key = (
+                    f"{record.param_name}__{record.condition}"
+                    if record.condition
+                    else record.param_name
                 )
+                pairs.setdefault(key, []).append((record.true_value, record.estimated_value))
                 if record.posterior_draws is not None:
-                    coverage_data.setdefault(record.param_name, []).append(
+                    coverage_data.setdefault(key, []).append(
                         (record.true_value, record.posterior_draws)
                     )
 
@@ -172,7 +175,7 @@ def _compute_coverage(
 def _hdi(draws: np.ndarray, prob: float) -> tuple[float, float]:
     """Compute highest density interval via shortest-interval method."""
 
-    sorted_draws = np.sort(draws)
+    sorted_draws = np.sort(np.ravel(draws))
     n = len(sorted_draws)
     interval_size = max(1, math.ceil(prob * n))
     if interval_size >= n:

--- a/src/comp_model/recovery/parameter/plotting.py
+++ b/src/comp_model/recovery/parameter/plotting.py
@@ -129,8 +129,8 @@ def plot_population_scatter(
 ) -> Any:
     """Plot true vs estimated scatter for population-level recovery.
 
-    One subplot per population parameter.  Each point represents one
-    replication.
+    One subplot per population parameter or condition-specific population
+    parameter. Each point represents one replication.
 
     Parameters
     ----------
@@ -153,10 +153,15 @@ def plot_population_scatter(
         if replication.population_level is None:
             continue
         for record in replication.population_level.records:
-            if params is not None and record.param_name not in params:
+            key = (
+                f"{record.param_name}__{record.condition}"
+                if record.condition
+                else record.param_name
+            )
+            if params is not None and key not in params:
                 continue
-            pairs[record.param_name][0].append(record.true_value)
-            pairs[record.param_name][1].append(record.estimated_value)
+            pairs[key][0].append(record.true_value)
+            pairs[key][1].append(record.estimated_value)
 
     param_keys = list(pairs)
     n_params = len(param_keys)

--- a/src/comp_model/recovery/parameter/result.py
+++ b/src/comp_model/recovery/parameter/result.py
@@ -47,6 +47,9 @@ class PopulationRecord:
     ----------
     param_name
         Population parameter name (e.g. ``alpha_pop``, ``mu_alpha_z``).
+    condition
+        Condition label for condition-specific population parameters, or
+        ``None`` for non-condition-aware population parameters.
     true_value
         Ground-truth population parameter value.
     estimated_value
@@ -56,6 +59,7 @@ class PopulationRecord:
     """
 
     param_name: str
+    condition: str | None
     true_value: float
     estimated_value: float
     posterior_draws: np.ndarray | None

--- a/src/comp_model/recovery/parameter/runner.py
+++ b/src/comp_model/recovery/parameter/runner.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 from comp_model.data.schema import Block, Dataset, SubjectData
 from comp_model.inference.bayes.result import BayesFitResult
 from comp_model.inference.dispatch import fit
-from comp_model.recovery.parameter.config import get_true_population_params, sample_true_params
+from comp_model.recovery.parameter.config import sample_true_params
 from comp_model.recovery.parameter.extraction import (
     extract_bayes_subject_records,
     extract_mle_subject_records,
@@ -62,7 +62,7 @@ def _build_true_population_values(
     true_table: dict[str, dict[str, float]],
     param_names: tuple[str, ...],
 ) -> dict[str, float]:
-    """Build true population values aligned with Stan posterior naming.
+    """Build constrained-scale population truths for recovery summaries.
 
     Parameters
     ----------
@@ -76,25 +76,15 @@ def _build_true_population_values(
     Returns
     -------
     dict[str, float]
-        True population values keyed to the names emitted by the Stan
-        adapter for the configured hierarchy.
+        True constrained-scale population values keyed to the constrained
+        population outputs emitted by Stan.
 
     Notes
     -----
-    For simple hierarchies this returns the empirical constrained-scale
-    population means (``{name}_pop``) plus any unconstrained-scale
-    ``mu_{name}_z`` / ``sd_{name}_z`` values available from
-    ``ParamDist(scale="unconstrained")``.
+    Population-level recovery reports only constrained-scale means:
 
-    For condition-aware hierarchies this returns:
-
-    - empirical baseline-condition constrained means as
-      ``{name}_shared_pop``, and
-    - unconstrained-scale shared and delta distribution moments as
-      ``mu_{name}_shared_z``, ``sd_{name}_shared_z``,
-      ``mu_{name}_delta_z``, and ``sd_{name}_delta_z`` when the
-      corresponding ``ParamDist`` entries were specified on the
-      unconstrained scale.
+    - ``{name}_pop`` for simple hierarchies
+    - ``{name}_shared_pop`` for condition-aware hierarchies
     """
 
     if config.layout is None:
@@ -103,12 +93,10 @@ def _build_true_population_values(
             vals = [true_table[sid][name] for sid in true_table if name in true_table[sid]]
             if vals:
                 true_pop[f"{name}_pop"] = float(np.mean(vals))
-        true_pop.update(get_true_population_params(config.param_dists, config.kernel))
         return true_pop
 
     true_pop = {}
     baseline_condition = config.layout.baseline_condition
-    dist_by_name = {dist.name: dist for dist in config.param_dists}
 
     for name in param_names:
         baseline_key = f"{name}__{baseline_condition}"
@@ -117,16 +105,6 @@ def _build_true_population_values(
         ]
         if vals:
             true_pop[f"{name}_shared_pop"] = float(np.mean(vals))
-
-        shared_dist = dist_by_name.get(name)
-        if shared_dist is not None and shared_dist.scale == "unconstrained":
-            true_pop[f"mu_{name}_shared_z"] = float(shared_dist.dist.mean())
-            true_pop[f"sd_{name}_shared_z"] = float(shared_dist.dist.std())
-
-        delta_dist = dist_by_name.get(f"{name}__delta")
-        if delta_dist is not None and delta_dist.scale == "unconstrained":
-            true_pop[f"mu_{name}_delta_z"] = float(delta_dist.dist.mean())
-            true_pop[f"sd_{name}_delta_z"] = float(delta_dist.dist.std())
 
     return true_pop
 
@@ -307,7 +285,7 @@ def _run_stan_recovery(config: ParameterRecoveryConfig) -> ParameterRecoveryResu
             config.layout,  # type: ignore[arg-type]
         )
         true_pop = _build_true_population_values(config, true_table, param_names)
-        pop_records = extract_population_records(result, true_pop)
+        pop_records = extract_population_records(result, true_pop, config.layout)
 
         return ReplicationResult(
             replication_index=r,

--- a/tests/test_recovery/test_extraction.py
+++ b/tests/test_recovery/test_extraction.py
@@ -314,8 +314,8 @@ class TestExtractPopulationRecords:
         assert records[0].estimated_value == pytest.approx(float(np.mean(posterior["alpha_pop"])))
         assert records[0].posterior_draws is not None
 
-    def test_unconstrained_keys(self) -> None:
-        """Unconstrained-scale mu/sd keys are extracted."""
+    def test_unconstrained_keys_are_skipped(self) -> None:
+        """Unconstrained-scale mu/sd keys are not reported."""
         rng = np.random.default_rng(11)
         n_draws = 100
         posterior = {
@@ -328,9 +328,7 @@ class TestExtractPopulationRecords:
 
         records = extract_population_records(result, true_pop)
 
-        assert len(records) == 2
-        names = {r.param_name for r in records}
-        assert names == {"mu_alpha_z", "sd_alpha_z"}
+        assert len(records) == 0
 
     def test_missing_true_pop_skipped(self) -> None:
         """Keys present in posterior but missing from true_pop are skipped."""
@@ -347,34 +345,53 @@ class TestExtractPopulationRecords:
 
         assert len(records) == 0
 
-    def test_condition_aware_keys(self) -> None:
-        """Condition-aware population keys (shared/delta) are extracted."""
+    def test_condition_aware_keys_only_keep_constrained_scale(self) -> None:
+        """Condition-aware population extraction keeps only constrained means."""
         rng = np.random.default_rng(13)
         n_draws = 100
         posterior = {
             "alpha_shared_pop": rng.normal(0.3, 0.005, size=n_draws),
             "mu_alpha_shared_z": rng.normal(0.0, 0.1, size=n_draws),
             "sd_alpha_shared_z": rng.normal(1.0, 0.1, size=n_draws),
-            "mu_alpha_delta_z": rng.normal(0.0, 0.1, size=n_draws),
-            "sd_alpha_delta_z": rng.normal(0.5, 0.1, size=n_draws),
         }
         result = _make_bayes_result(posterior)
         true_pop = {
             "alpha_shared_pop": 0.30,
             "mu_alpha_shared_z": 0.0,
             "sd_alpha_shared_z": 1.0,
-            "mu_alpha_delta_z": 0.0,
-            "sd_alpha_delta_z": 0.5,
         }
 
         records = extract_population_records(result, true_pop)
 
-        assert len(records) == 5
+        assert len(records) == 1
         names = {r.param_name for r in records}
-        assert names == {
-            "alpha_shared_pop",
-            "mu_alpha_shared_z",
-            "sd_alpha_shared_z",
-            "mu_alpha_delta_z",
-            "sd_alpha_delta_z",
+        assert names == {"alpha_shared_pop"}
+
+    def test_condition_aware_vector_delta_keys_are_skipped(self) -> None:
+        """Vector-valued unconstrained delta keys are not reported."""
+        from comp_model.models.condition.shared_delta import SharedDeltaLayout
+        from comp_model.models.kernels import AsocialQLearningKernel
+
+        rng = np.random.default_rng(14)
+        n_draws = 100
+        posterior = {
+            "mu_alpha_delta_z": rng.normal(0.0, 0.1, size=(n_draws, 2)),
+            "sd_alpha_delta_z": rng.normal(0.5, 0.1, size=(n_draws, 2)),
         }
+        result = _make_bayes_result(
+            posterior,
+            HierarchyStructure.STUDY_SUBJECT_BLOCK_CONDITION,
+        )
+        layout = SharedDeltaLayout(
+            kernel_spec=AsocialQLearningKernel.spec(),
+            conditions=("baseline", "social", "transfer"),
+            baseline_condition="baseline",
+        )
+        true_pop = {
+            "mu_alpha_delta_z": 0.0,
+            "sd_alpha_delta_z": 0.5,
+        }
+
+        records = extract_population_records(result, true_pop, layout=layout)
+
+        assert records == ()

--- a/tests/test_recovery/test_metrics.py
+++ b/tests/test_recovery/test_metrics.py
@@ -1,0 +1,51 @@
+"""Tests for parameter recovery metrics."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from comp_model.recovery.parameter.metrics import compute_parameter_recovery_metrics
+from comp_model.recovery.parameter.result import (
+    ParameterRecoveryResult,
+    PopulationLevelResult,
+    PopulationRecord,
+    ReplicationResult,
+    SubjectLevelResult,
+)
+
+
+class TestComputeParameterRecoveryMetrics:
+    """Tests for pooled recovery metric computation."""
+
+    def test_population_condition_keys_are_scored_without_hdi_crashes(self) -> None:
+        """Condition-specific population records should be keyed and scored safely."""
+
+        result = ParameterRecoveryResult(
+            config=None,  # type: ignore[arg-type]
+            replications=(
+                ReplicationResult(
+                    replication_index=0,
+                    subject_level=SubjectLevelResult(records=()),
+                    population_level=PopulationLevelResult(
+                        records=(
+                            PopulationRecord(
+                                param_name="mu_alpha_delta_z",
+                                condition="social",
+                                true_value=-0.4,
+                                estimated_value=-0.39,
+                                posterior_draws=np.linspace(-0.5, -0.3, 101),
+                            ),
+                        )
+                    ),
+                ),
+            ),
+        )
+
+        metrics = compute_parameter_recovery_metrics(result)
+
+        assert set(metrics.per_parameter) == {"mu_alpha_delta_z__social"}
+        metric = metrics.per_parameter["mu_alpha_delta_z__social"]
+        assert metric.n_observations == 1
+        assert metric.coverage_90 == pytest.approx(1.0)
+        assert metric.coverage_95 == pytest.approx(1.0)

--- a/tests/test_recovery/test_parameter_runner.py
+++ b/tests/test_recovery/test_parameter_runner.py
@@ -193,10 +193,10 @@ class TestRunParameterRecovery:
                 "sd_alpha_shared_z": np.full(n_draws, 0.2),
                 "mu_beta_shared_z": np.full(n_draws, 1.0),
                 "sd_beta_shared_z": np.full(n_draws, 0.3),
-                "mu_alpha_delta_z": np.full(n_draws, -0.4),
-                "sd_alpha_delta_z": np.full(n_draws, 0.1),
-                "mu_beta_delta_z": np.full(n_draws, 0.5),
-                "sd_beta_delta_z": np.full(n_draws, 0.2),
+                "mu_alpha_delta_z": np.full((n_draws, 1), -0.4),
+                "sd_alpha_delta_z": np.full((n_draws, 1), 0.1),
+                "mu_beta_delta_z": np.full((n_draws, 1), 0.5),
+                "sd_beta_delta_z": np.full((n_draws, 1), 0.2),
             }
             return BayesFitResult(
                 model_id="asocial_q_learning",
@@ -217,26 +217,12 @@ class TestRunParameterRecovery:
         population_level = result.replications[0].population_level
         assert population_level is not None
 
-        records = {record.param_name: record for record in population_level.records}
-        assert set(records) == {
-            "alpha_shared_pop",
-            "beta_shared_pop",
-            "mu_alpha_shared_z",
-            "sd_alpha_shared_z",
-            "mu_beta_shared_z",
-            "sd_beta_shared_z",
-            "mu_alpha_delta_z",
-            "sd_alpha_delta_z",
-            "mu_beta_delta_z",
-            "sd_beta_delta_z",
+        records = {
+            (record.param_name, record.condition): record for record in population_level.records
         }
-        assert records["alpha_shared_pop"].true_value == pytest.approx(0.45)
-        assert records["beta_shared_pop"].true_value == pytest.approx(1.25)
-        assert records["mu_alpha_shared_z"].true_value == pytest.approx(0.1)
-        assert records["sd_alpha_shared_z"].true_value == pytest.approx(0.2)
-        assert records["mu_beta_shared_z"].true_value == pytest.approx(1.0)
-        assert records["sd_beta_shared_z"].true_value == pytest.approx(0.3)
-        assert records["mu_alpha_delta_z"].true_value == pytest.approx(-0.4)
-        assert records["sd_alpha_delta_z"].true_value == pytest.approx(0.1)
-        assert records["mu_beta_delta_z"].true_value == pytest.approx(0.5)
-        assert records["sd_beta_delta_z"].true_value == pytest.approx(0.2)
+        assert set(records) == {
+            ("alpha_shared_pop", None),
+            ("beta_shared_pop", None),
+        }
+        assert records[("alpha_shared_pop", None)].true_value == pytest.approx(0.45)
+        assert records[("beta_shared_pop", None)].true_value == pytest.approx(1.25)


### PR DESCRIPTION
## Summary
- Reverts the revert (PR #65) to re-apply the original PR #62 changes
- Adds `condition` field to `PopulationRecord` and splits vector-valued delta posteriors per condition
- Updates metrics, plotting, CSV, and extraction to handle condition-qualified population keys

## Context
PR #62 was merged then reverted via PR #65. This PR re-applies those changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)