### PR TITLE
feat(recovery): add social model recovery among M1, M3, M4c, M7c

### DIFF
--- a/example/model_recovery/social_model_recovery.py
+++ b/example/model_recovery/social_model_recovery.py
@@ -107,12 +107,6 @@ STAN_CONFIG_CONDITION = InferenceConfig(
     stan_config=StanFitConfig(n_warmup=1000, n_samples=1000, n_chains=4, seed=42),
 )
 
-STAN_CONFIG_SIMPLE = InferenceConfig(
-    hierarchy=HierarchyStructure.STUDY_SUBJECT,
-    backend="stan",
-    stan_config=StanFitConfig(n_warmup=1000, n_samples=1000, n_chains=4, seed=42),
-)
-
 # ---------------------------------------------------------------------------
 # Layouts
 # ---------------------------------------------------------------------------

--- a/src/comp_model/recovery/model/config.py
+++ b/src/comp_model/recovery/model/config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
@@ -118,6 +118,6 @@ class ModelRecoveryConfig:
     criterion: Literal["aic", "bic", "log_likelihood", "waic", "loo"] = "aic"
     demonstrator_kernel: ModelKernel[Any, Any] | None = None
     demonstrator_params: Any | None = None
-    condition_demonstrator_params: dict[str, Any] | None = field(default=None)
+    condition_demonstrator_params: dict[str, Any] | None = None
     simulation_base_seed: int = 42
     max_workers: int | None = None

--- a/src/comp_model/recovery/model/runner.py
+++ b/src/comp_model/recovery/model/runner.py
@@ -145,11 +145,15 @@ def _simulate_generated_dataset(
                     f"task condition {condition!r}"
                 )
             # Resolve per-condition demonstrator params
-            demo_params = (
-                config.condition_demonstrator_params[condition]
-                if config.condition_demonstrator_params is not None
-                else config.demonstrator_params
-            )
+            demo_params = config.demonstrator_params
+            if config.condition_demonstrator_params is not None:
+                if condition not in config.condition_demonstrator_params:
+                    raise ValueError(
+                        f"Generating model {gen_spec.name!r} is missing demonstrator "
+                        f"parameters for task condition {condition!r} in "
+                        f"'condition_demonstrator_params'"
+                    )
+                demo_params = config.condition_demonstrator_params[condition]
             env = config.env_factory()
             subject = simulate_subject(
                 task=TaskSpec(task_id="tmp", blocks=(block_spec,)),


### PR DESCRIPTION
## Summary
- Add `demonstrator_kernel`, `demonstrator_params`, and `condition_demonstrator_params` fields to `ModelRecoveryConfig` so social kernels can be simulated with condition-specific demonstrator behaviour
- Update `_simulate_generated_dataset` in the model recovery runner to pass demonstrator info to both `simulate_dataset` (flat case) and `simulate_subject` (layout/per-block case)
- Add `example/model_recovery/social_model_recovery.py` — a WAIC-based model recovery script comparing four models:
  - **M1** (AsocialQLearning): α, β
  - **M3** (SocialRlSelfRewardDemoReward): α_self, α_other, β
  - **M4c** (SocialRlSelfRewardDemoActionMixture): α_self, α_other_action, w_imitation, β
  - **M7c** (SocialRlSelfRewardDemoMixture): α_self, α_other_outcome, α_other_action, w_imitation, β

## Test plan
- [ ] Verify `ModelRecoveryConfig` accepts new demonstrator fields without breaking existing usage (defaults to `None`)
- [ ] Verify the example script imports successfully: `python -c "import example.model_recovery.social_model_recovery"`
- [ ] Run a short smoke test with reduced replications/subjects to confirm end-to-end execution
- [ ] Confirm existing model recovery tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)