### PR TITLE
feat(recovery): use hierarchical sampling in social model recovery an…

### DIFF
--- a/example/model_recovery/social_model_recovery.py
+++ b/example/model_recovery/social_model_recovery.py
@@ -7,10 +7,12 @@ Compares four models that span the asocial-to-social learning spectrum:
 - Model 4c : SocialRlSelfRewardDemoActionMixture — own reward + demo action (mixture)
 - Model 7c : SocialRlSelfRewardDemoMixture — own reward + demo reward + demo action (full mixture)
 
-All models are simulated and fitted using the social pre-choice schema with
-two demonstrator conditions (strong vs. weak). Hierarchical Stan inference
-with STUDY_SUBJECT_BLOCK_CONDITION hierarchy is used for fitting. Model
-selection is based on WAIC.
+All models are simulated using hierarchical sampling (population mu/sd drawn
+from priors, then per-subject parameters drawn from Normal(mu, sd)) and
+fitted using the social pre-choice schema with two demonstrator conditions
+(strong vs. weak). Hierarchical Stan inference with
+STUDY_SUBJECT_BLOCK_CONDITION hierarchy is used for fitting. Model selection
+is based on WAIC.
 
 Usage
 -----
@@ -38,7 +40,7 @@ from comp_model.models.kernels import (
     SocialRlSelfRewardDemoMixtureKernel,
     SocialRlSelfRewardDemoRewardKernel,
 )
-from comp_model.recovery import FlatParamDist
+from comp_model.recovery import HierarchicalParamDist
 from comp_model.recovery.model import (
     CandidateModelSpec,
     GeneratingModelSpec,
@@ -145,10 +147,16 @@ generating_models = (
         name="M1_Asocial",
         kernel=AsocialQLearningKernel(),
         param_dists=(
-            FlatParamDist("alpha", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("beta", stats.uniform(-1, 6), scale="unconstrained"),
-            FlatParamDist("alpha__delta", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("beta__delta", stats.uniform(-3, 6), scale="unconstrained"),
+            HierarchicalParamDist(
+                "alpha", mu_prior=stats.norm(0, 1), sd_prior=stats.halfnorm(0, 1)
+            ),
+            HierarchicalParamDist("beta", mu_prior=stats.norm(1, 1), sd_prior=stats.halfnorm(0, 1)),
+            HierarchicalParamDist(
+                "alpha__delta", mu_prior=stats.norm(0, 0.5), sd_prior=stats.halfnorm(0, 0.5)
+            ),
+            HierarchicalParamDist(
+                "beta__delta", mu_prior=stats.norm(0, 0.5), sd_prior=stats.halfnorm(0, 0.5)
+            ),
         ),
         layout=layout_model1,
     ),
@@ -157,12 +165,22 @@ generating_models = (
         name="M3_DemoReward",
         kernel=SocialRlSelfRewardDemoRewardKernel(),
         param_dists=(
-            FlatParamDist("alpha_self", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("alpha_other", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("beta", stats.uniform(-1, 6), scale="unconstrained"),
-            FlatParamDist("alpha_self__delta", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("alpha_other__delta", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("beta__delta", stats.uniform(-3, 6), scale="unconstrained"),
+            HierarchicalParamDist(
+                "alpha_self", mu_prior=stats.norm(0, 1), sd_prior=stats.halfnorm(0, 1)
+            ),
+            HierarchicalParamDist(
+                "alpha_other", mu_prior=stats.norm(0, 1), sd_prior=stats.halfnorm(0, 1)
+            ),
+            HierarchicalParamDist("beta", mu_prior=stats.norm(1, 1), sd_prior=stats.halfnorm(0, 1)),
+            HierarchicalParamDist(
+                "alpha_self__delta", mu_prior=stats.norm(0, 0.5), sd_prior=stats.halfnorm(0, 0.5)
+            ),
+            HierarchicalParamDist(
+                "alpha_other__delta", mu_prior=stats.norm(0, 0.5), sd_prior=stats.halfnorm(0, 0.5)
+            ),
+            HierarchicalParamDist(
+                "beta__delta", mu_prior=stats.norm(0, 0.5), sd_prior=stats.halfnorm(0, 0.5)
+            ),
         ),
         layout=layout_model3,
     ),
@@ -172,14 +190,30 @@ generating_models = (
         name="M4c_DemoAction",
         kernel=SocialRlSelfRewardDemoActionMixtureKernel(),
         param_dists=(
-            FlatParamDist("alpha_self", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("alpha_other_action", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("w_imitation", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("beta", stats.uniform(-1, 6), scale="unconstrained"),
-            FlatParamDist("alpha_self__delta", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("alpha_other_action__delta", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("w_imitation__delta", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("beta__delta", stats.uniform(-3, 6), scale="unconstrained"),
+            HierarchicalParamDist(
+                "alpha_self", mu_prior=stats.norm(0, 1), sd_prior=stats.halfnorm(0, 1)
+            ),
+            HierarchicalParamDist(
+                "alpha_other_action", mu_prior=stats.norm(0, 1), sd_prior=stats.halfnorm(0, 1)
+            ),
+            HierarchicalParamDist(
+                "w_imitation", mu_prior=stats.norm(0, 1), sd_prior=stats.halfnorm(0, 1)
+            ),
+            HierarchicalParamDist("beta", mu_prior=stats.norm(1, 1), sd_prior=stats.halfnorm(0, 1)),
+            HierarchicalParamDist(
+                "alpha_self__delta", mu_prior=stats.norm(0, 0.5), sd_prior=stats.halfnorm(0, 0.5)
+            ),
+            HierarchicalParamDist(
+                "alpha_other_action__delta",
+                mu_prior=stats.norm(0, 0.5),
+                sd_prior=stats.halfnorm(0, 0.5),
+            ),
+            HierarchicalParamDist(
+                "w_imitation__delta", mu_prior=stats.norm(0, 0.5), sd_prior=stats.halfnorm(0, 0.5)
+            ),
+            HierarchicalParamDist(
+                "beta__delta", mu_prior=stats.norm(0, 0.5), sd_prior=stats.halfnorm(0, 0.5)
+            ),
         ),
         layout=layout_model4c,
     ),
@@ -189,18 +223,38 @@ generating_models = (
         name="M7c_FullMixture",
         kernel=SocialRlSelfRewardDemoMixtureKernel(),
         param_dists=(
-            FlatParamDist("alpha_self", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("alpha_other_outcome", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("alpha_other_action", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("w_imitation", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("beta", stats.uniform(-1, 6), scale="unconstrained"),
-            FlatParamDist("alpha_self__delta", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist(
-                "alpha_other_outcome__delta", stats.uniform(-3, 6), scale="unconstrained"
+            HierarchicalParamDist(
+                "alpha_self", mu_prior=stats.norm(0, 1), sd_prior=stats.halfnorm(0, 1)
             ),
-            FlatParamDist("alpha_other_action__delta", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("w_imitation__delta", stats.uniform(-3, 6), scale="unconstrained"),
-            FlatParamDist("beta__delta", stats.uniform(-3, 6), scale="unconstrained"),
+            HierarchicalParamDist(
+                "alpha_other_outcome", mu_prior=stats.norm(0, 1), sd_prior=stats.halfnorm(0, 1)
+            ),
+            HierarchicalParamDist(
+                "alpha_other_action", mu_prior=stats.norm(0, 1), sd_prior=stats.halfnorm(0, 1)
+            ),
+            HierarchicalParamDist(
+                "w_imitation", mu_prior=stats.norm(0, 1), sd_prior=stats.halfnorm(0, 1)
+            ),
+            HierarchicalParamDist("beta", mu_prior=stats.norm(1, 1), sd_prior=stats.halfnorm(0, 1)),
+            HierarchicalParamDist(
+                "alpha_self__delta", mu_prior=stats.norm(0, 0.5), sd_prior=stats.halfnorm(0, 0.5)
+            ),
+            HierarchicalParamDist(
+                "alpha_other_outcome__delta",
+                mu_prior=stats.norm(0, 0.5),
+                sd_prior=stats.halfnorm(0, 0.5),
+            ),
+            HierarchicalParamDist(
+                "alpha_other_action__delta",
+                mu_prior=stats.norm(0, 0.5),
+                sd_prior=stats.halfnorm(0, 0.5),
+            ),
+            HierarchicalParamDist(
+                "w_imitation__delta", mu_prior=stats.norm(0, 0.5), sd_prior=stats.halfnorm(0, 0.5)
+            ),
+            HierarchicalParamDist(
+                "beta__delta", mu_prior=stats.norm(0, 0.5), sd_prior=stats.halfnorm(0, 0.5)
+            ),
         ),
         layout=layout_model7c,
     ),

--- a/src/comp_model/recovery/model/runner.py
+++ b/src/comp_model/recovery/model/runner.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import contextlib
 import dataclasses
+import importlib
 import os
 import sys
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 import numpy as np
 from tqdm import tqdm
@@ -44,6 +43,41 @@ _CONDITION_HIERARCHIES = (
     HierarchyStructure.SUBJECT_BLOCK_CONDITION,
     HierarchyStructure.STUDY_SUBJECT_BLOCK_CONDITION,
 )
+
+
+def _precompile_stan_models(config: ModelRecoveryConfig) -> None:
+    """Pre-compile all unique Stan programs before parallel fitting.
+
+    Parameters
+    ----------
+    config
+        Model recovery configuration containing candidate model specs.
+
+    Notes
+    -----
+    CmdStanPy compilation is not safe for concurrent access.  When multiple
+    ``ProcessPoolExecutor`` workers call ``CmdStanModel`` on the same
+    ``.stan`` file simultaneously, one process may delete intermediate build
+    artefacts while another still expects them, causing a
+    ``FileNotFoundError``.  Compiling once in the main process ensures the
+    cached executable is available for all workers.
+    """
+    seen: set[str] = set()
+    cmdstanpy = importlib.import_module("cmdstanpy")
+
+    for cand in config.candidate_models:
+        if cand.inference_config.backend != "stan" or cand.adapter is None:
+            continue
+        adapter: Any = cand.adapter
+        stan_file: str = adapter.stan_program_path(cand.inference_config.hierarchy)
+        if stan_file in seen:
+            continue
+        seen.add(stan_file)
+        functions_dir = str(Path(stan_file).parent / "functions")
+        cmdstanpy.CmdStanModel(
+            stan_file=stan_file,
+            stanc_options={"include-paths": [functions_dir]},
+        )
 
 
 def _check_schema_consistency(task: TaskSpec, schema: TrialSchema) -> None:
@@ -268,6 +302,11 @@ def run_model_recovery(config: ModelRecoveryConfig) -> ModelRecoveryResult:
             key = (gen_spec.name, rep_idx)
             simulated[key] = dataset
             gen_rep_order.append(key)
+
+    # ------------------------------------------------------------------
+    # Phase 1.5: pre-compile Stan programs (avoids parallel race condition)
+    # ------------------------------------------------------------------
+    _precompile_stan_models(config)
 
     # ------------------------------------------------------------------
     # Phase 2: fit — one job per (generating_model, candidate, replication)


### PR DESCRIPTION
…d fix parallel Stan compilation

Replace FlatParamDist with HierarchicalParamDist in social_model_recovery.py so generating models draw population mu/sd from priors then sample per-subject parameters from Normal(mu, sd). Also pre-compile Stan programs in the main process before spawning parallel workers to avoid a CmdStanPy race condition where concurrent compilations delete each other's intermediate build artefacts.