### PR TITLE
[codex] Support configurable hierarchical SD priors

### DIFF
--- a/src/comp_model/inference/bayes/stan/__init__.py
+++ b/src/comp_model/inference/bayes/stan/__init__.py
@@ -17,6 +17,7 @@ from comp_model.inference.bayes.stan.backend import (
 from comp_model.inference.bayes.stan.data_builder import (
     add_condition_data,
     add_prior_data,
+    add_sd_prior_data,
     add_state_reset_data,
     dataset_to_stan_data,
     subject_to_stan_data,
@@ -34,6 +35,7 @@ __all__ = (
     "StanFitConfig",
     "add_condition_data",
     "add_prior_data",
+    "add_sd_prior_data",
     "add_state_reset_data",
     "dataset_to_stan_data",
     "fit_stan",

--- a/src/comp_model/inference/bayes/stan/adapters/asocial_q_learning.py
+++ b/src/comp_model/inference/bayes/stan/adapters/asocial_q_learning.py
@@ -14,6 +14,7 @@ from comp_model.inference.bayes.stan.adapters.base import require_layout_for_con
 from comp_model.inference.bayes.stan.data_builder import (
     add_initial_value_data,
     add_prior_data,
+    add_sd_prior_data,
     add_state_reset_data,
     dataset_to_step_data,
     subject_to_step_data,
@@ -129,6 +130,10 @@ class AsocialQLearningStanAdapter:
 
         # Add prior, reset, and initial value data
         add_prior_data(stan_data, kspec, prior_specs)
+        if hierarchy == HierarchyStructure.STUDY_SUBJECT:
+            add_sd_prior_data(stan_data, kspec, prior_specs)
+        elif hierarchy == HierarchyStructure.STUDY_SUBJECT_BLOCK_CONDITION:
+            add_sd_prior_data(stan_data, kspec, prior_specs, include_delta=True)
         add_state_reset_data(stan_data, kspec)
         add_initial_value_data(stan_data, 0.5)
 

--- a/src/comp_model/inference/bayes/stan/adapters/asocial_rl_asymmetric.py
+++ b/src/comp_model/inference/bayes/stan/adapters/asocial_rl_asymmetric.py
@@ -10,6 +10,7 @@ from comp_model.inference.bayes.stan.adapters.base import require_layout_for_con
 from comp_model.inference.bayes.stan.data_builder import (
     add_initial_value_data,
     add_prior_data,
+    add_sd_prior_data,
     add_state_reset_data,
     dataset_to_step_data,
     subject_to_step_data,
@@ -120,6 +121,10 @@ class AsocialRlAsymmetricStanAdapter:
             )
 
         add_prior_data(stan_data, kspec, prior_specs)
+        if hierarchy == HierarchyStructure.STUDY_SUBJECT:
+            add_sd_prior_data(stan_data, kspec, prior_specs)
+        elif hierarchy == HierarchyStructure.STUDY_SUBJECT_BLOCK_CONDITION:
+            add_sd_prior_data(stan_data, kspec, prior_specs, include_delta=True)
         add_state_reset_data(stan_data, kspec)
         add_initial_value_data(stan_data, 0.5)
 

--- a/src/comp_model/inference/bayes/stan/adapters/social_rl_demo_mixture.py
+++ b/src/comp_model/inference/bayes/stan/adapters/social_rl_demo_mixture.py
@@ -10,6 +10,7 @@ from comp_model.inference.bayes.stan.adapters.base import require_layout_for_con
 from comp_model.inference.bayes.stan.data_builder import (
     add_initial_value_data,
     add_prior_data,
+    add_sd_prior_data,
     add_state_reset_data,
     dataset_to_step_data,
     subject_to_step_data,
@@ -153,6 +154,10 @@ class SocialRlDemoMixtureStanAdapter:
             )
 
         add_prior_data(stan_data, kspec, prior_specs)
+        if hierarchy == HierarchyStructure.STUDY_SUBJECT:
+            add_sd_prior_data(stan_data, kspec, prior_specs)
+        elif hierarchy == HierarchyStructure.STUDY_SUBJECT_BLOCK_CONDITION:
+            add_sd_prior_data(stan_data, kspec, prior_specs, include_delta=True)
         add_state_reset_data(stan_data, kspec)
         add_initial_value_data(stan_data, kernel.v_outcome_init)
 

--- a/src/comp_model/inference/bayes/stan/adapters/social_rl_self_reward_demo_action_mixture.py
+++ b/src/comp_model/inference/bayes/stan/adapters/social_rl_self_reward_demo_action_mixture.py
@@ -10,6 +10,7 @@ from comp_model.inference.bayes.stan.adapters.base import require_layout_for_con
 from comp_model.inference.bayes.stan.data_builder import (
     add_initial_value_data,
     add_prior_data,
+    add_sd_prior_data,
     add_state_reset_data,
     dataset_to_step_data,
     subject_to_step_data,
@@ -152,6 +153,10 @@ class SocialRlSelfRewardDemoActionMixtureStanAdapter:
             )
 
         add_prior_data(stan_data, kspec, prior_specs)
+        if hierarchy == HierarchyStructure.STUDY_SUBJECT:
+            add_sd_prior_data(stan_data, kspec, prior_specs)
+        elif hierarchy == HierarchyStructure.STUDY_SUBJECT_BLOCK_CONDITION:
+            add_sd_prior_data(stan_data, kspec, prior_specs, include_delta=True)
         add_state_reset_data(stan_data, kspec)
         add_initial_value_data(stan_data, kernel.v_outcome_init)
         # v_tendency is initialised to 1/A inside each Stan program; no data entry needed

--- a/src/comp_model/inference/bayes/stan/adapters/social_rl_self_reward_demo_mixture.py
+++ b/src/comp_model/inference/bayes/stan/adapters/social_rl_self_reward_demo_mixture.py
@@ -10,6 +10,7 @@ from comp_model.inference.bayes.stan.adapters.base import require_layout_for_con
 from comp_model.inference.bayes.stan.data_builder import (
     add_initial_value_data,
     add_prior_data,
+    add_sd_prior_data,
     add_state_reset_data,
     dataset_to_step_data,
     subject_to_step_data,
@@ -153,6 +154,10 @@ class SocialRlSelfRewardDemoMixtureStanAdapter:
             )
 
         add_prior_data(stan_data, kspec, prior_specs)
+        if hierarchy == HierarchyStructure.STUDY_SUBJECT:
+            add_sd_prior_data(stan_data, kspec, prior_specs)
+        elif hierarchy == HierarchyStructure.STUDY_SUBJECT_BLOCK_CONDITION:
+            add_sd_prior_data(stan_data, kspec, prior_specs, include_delta=True)
         add_state_reset_data(stan_data, kspec)
         add_initial_value_data(stan_data, kernel.v_outcome_init)
         # v_tendency is initialised to 1/A inside each Stan program; no data entry needed

--- a/src/comp_model/inference/bayes/stan/adapters/social_rl_self_reward_demo_reward.py
+++ b/src/comp_model/inference/bayes/stan/adapters/social_rl_self_reward_demo_reward.py
@@ -14,6 +14,7 @@ from comp_model.inference.bayes.stan.adapters.base import require_layout_for_con
 from comp_model.inference.bayes.stan.data_builder import (
     add_initial_value_data,
     add_prior_data,
+    add_sd_prior_data,
     add_state_reset_data,
     dataset_to_step_data,
     subject_to_step_data,
@@ -137,6 +138,10 @@ class SocialRlSelfRewardDemoRewardStanAdapter:
             )
 
         add_prior_data(stan_data, kspec, prior_specs)
+        if hierarchy == HierarchyStructure.STUDY_SUBJECT:
+            add_sd_prior_data(stan_data, kspec, prior_specs)
+        elif hierarchy == HierarchyStructure.STUDY_SUBJECT_BLOCK_CONDITION:
+            add_sd_prior_data(stan_data, kspec, prior_specs, include_delta=True)
         add_state_reset_data(stan_data, kspec)
         add_initial_value_data(stan_data, 0.5)
 

--- a/src/comp_model/inference/bayes/stan/data_builder.py
+++ b/src/comp_model/inference/bayes/stan/data_builder.py
@@ -315,6 +315,78 @@ def add_prior_data(
         stan_data[f"{parameter.name}_prior_p3"] = p3
 
 
+def add_sd_prior_data(
+    stan_data: dict[str, Any],
+    kernel_spec: ModelKernelSpec,
+    prior_specs: dict[str, PriorSpec] | None = None,
+    *,
+    include_delta: bool = False,
+) -> None:
+    """Add standard-deviation prior hyperparameters to a Stan data dictionary.
+
+    Parameters
+    ----------
+    stan_data
+        Stan data dictionary to mutate.
+    kernel_spec
+        Kernel specification whose parameter names drive the export.
+    prior_specs
+        Optional mapping from prior name to prior specification.
+        SD priors are looked up with the ``sd_`` prefix (e.g.,
+        ``"sd_alpha"``).  Parameters without an entry fall back to
+        ``Normal(0, 1)`` on the unconstrained scale.
+    include_delta
+        When ``True``, also export SD priors for condition-hierarchy delta
+        parameters.  Delta SD priors are looked up as
+        ``"sd_{name}_delta"``; if absent, they fall back to the
+        base SD prior ``"sd_{name}"``, then to ``Normal(0, 1)``.
+
+    Returns
+    -------
+    None
+        This function mutates ``stan_data`` in-place.
+
+    Notes
+    -----
+    Each parameter exports a ``(family, p1, p2, p3)`` tuple consumed by the
+    shared ``prior_lpdf`` Stan function, prefixed with ``sd_``.  The default
+    prior is ``Normal(0, 1)`` — tighter than the parameter-level default of
+    ``Normal(0, 2)`` — because SD parameters typically require stronger
+    regularisation in hierarchical models.
+    """
+
+    priors = prior_specs or {}
+    default = (1, 0.0, 1.0, 0.0)  # Normal(0, 1)
+
+    for parameter in kernel_spec.parameter_specs:
+        sd_key = f"sd_{parameter.name}"
+        prior = priors.get(sd_key)
+        if prior is not None:
+            family_id, p1, p2, p3 = prior_spec_to_stan_data(prior.family, prior.kwargs)
+        else:
+            family_id, p1, p2, p3 = default
+        stan_data[f"{sd_key}_prior_family"] = family_id
+        stan_data[f"{sd_key}_prior_p1"] = p1
+        stan_data[f"{sd_key}_prior_p2"] = p2
+        stan_data[f"{sd_key}_prior_p3"] = p3
+
+        if include_delta:
+            delta_key = f"sd_{parameter.name}_delta"
+            delta_prior = priors.get(delta_key)
+            if delta_prior is not None:
+                family_id, p1, p2, p3 = prior_spec_to_stan_data(
+                    delta_prior.family, delta_prior.kwargs
+                )
+            elif prior is not None:
+                family_id, p1, p2, p3 = prior_spec_to_stan_data(prior.family, prior.kwargs)
+            else:
+                family_id, p1, p2, p3 = default
+            stan_data[f"{delta_key}_prior_family"] = family_id
+            stan_data[f"{delta_key}_prior_p1"] = p1
+            stan_data[f"{delta_key}_prior_p2"] = p2
+            stan_data[f"{delta_key}_prior_p3"] = p3
+
+
 def add_state_reset_data(stan_data: dict[str, Any], kernel_spec: ModelKernelSpec) -> None:
     """Add kernel state-reset metadata to a Stan data dictionary.
 

--- a/src/comp_model/inference/bayes/stan/programs/asocial_q_learning__study_subject_block_condition_hierarchy.stan
+++ b/src/comp_model/inference/bayes/stan/programs/asocial_q_learning__study_subject_block_condition_hierarchy.stan
@@ -36,6 +36,22 @@ data {
   real beta_prior_p1;       // first hyperparameter of the beta prior
   real beta_prior_p2;       // second hyperparameter of the beta prior
   real beta_prior_p3;       // third hyperparameter of the beta prior
+  int sd_alpha_prior_family;   // prior family code for the group-level shared alpha SD
+  real sd_alpha_prior_p1;      // first hyperparameter of the shared alpha SD prior
+  real sd_alpha_prior_p2;      // second hyperparameter of the shared alpha SD prior
+  real sd_alpha_prior_p3;      // third hyperparameter of the shared alpha SD prior
+  int sd_beta_prior_family;    // prior family code for the group-level shared beta SD
+  real sd_beta_prior_p1;       // first hyperparameter of the shared beta SD prior
+  real sd_beta_prior_p2;       // second hyperparameter of the shared beta SD prior
+  real sd_beta_prior_p3;       // third hyperparameter of the shared beta SD prior
+  int sd_alpha_delta_prior_family;   // prior family code for the group-level alpha delta SD
+  real sd_alpha_delta_prior_p1;      // first hyperparameter of the alpha delta SD prior
+  real sd_alpha_delta_prior_p2;      // second hyperparameter of the alpha delta SD prior
+  real sd_alpha_delta_prior_p3;      // third hyperparameter of the alpha delta SD prior
+  int sd_beta_delta_prior_family;    // prior family code for the group-level beta delta SD
+  real sd_beta_delta_prior_p1;       // first hyperparameter of the beta delta SD prior
+  real sd_beta_delta_prior_p2;       // second hyperparameter of the beta delta SD prior
+  real sd_beta_delta_prior_p3;       // third hyperparameter of the beta delta SD prior
 }
 parameters {
   // Population-level: shared
@@ -93,18 +109,20 @@ model {
 
   // Priors: shared
   target += prior_lpdf(mu_alpha_shared_z | alpha_prior_family, alpha_prior_p1, alpha_prior_p2, alpha_prior_p3);
-  sd_alpha_shared_z ~ normal(0, 1);   // half-normal prior on group SD
+  target += prior_lpdf(sd_alpha_shared_z | sd_alpha_prior_family, sd_alpha_prior_p1, sd_alpha_prior_p2, sd_alpha_prior_p3);
   raw_alpha_shared_z ~ normal(0, 1);  // non-centred parameterisation
 
   target += prior_lpdf(mu_beta_shared_z | beta_prior_family, beta_prior_p1, beta_prior_p2, beta_prior_p3);
-  sd_beta_shared_z ~ normal(0, 1);
+  target += prior_lpdf(sd_beta_shared_z | sd_beta_prior_family, sd_beta_prior_p1, sd_beta_prior_p2, sd_beta_prior_p3);
   raw_beta_shared_z ~ normal(0, 1);
 
   // Priors: deltas
   mu_alpha_delta_z ~ normal(0, 1);   // regularising prior on group-level delta means
-  sd_alpha_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_alpha_delta_z[d] | sd_alpha_delta_prior_family, sd_alpha_delta_prior_p1, sd_alpha_delta_prior_p2, sd_alpha_delta_prior_p3);
   mu_beta_delta_z ~ normal(0, 1);
-  sd_beta_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_beta_delta_z[d] | sd_beta_delta_prior_family, sd_beta_delta_prior_p1, sd_beta_delta_prior_p2, sd_beta_delta_prior_p3);
   for (d in 1:(C - 1)) {
     raw_alpha_delta_z[d] ~ normal(0, 1); // non-centred deviates for per-subject alpha deltas
     raw_beta_delta_z[d] ~ normal(0, 1);

--- a/src/comp_model/inference/bayes/stan/programs/asocial_q_learning__study_subject_hierarchy.stan
+++ b/src/comp_model/inference/bayes/stan/programs/asocial_q_learning__study_subject_hierarchy.stan
@@ -28,10 +28,18 @@ data {
   real alpha_prior_p1;      // first hyperparameter of the alpha prior
   real alpha_prior_p2;      // second hyperparameter of the alpha prior
   real alpha_prior_p3;      // third hyperparameter of the alpha prior
+  int sd_alpha_prior_family;   // prior family code for the group-level alpha SD
+  real sd_alpha_prior_p1;      // first hyperparameter of the alpha SD prior
+  real sd_alpha_prior_p2;      // second hyperparameter of the alpha SD prior
+  real sd_alpha_prior_p3;      // third hyperparameter of the alpha SD prior
   int beta_prior_family;    // prior family code for the group-level beta mean
   real beta_prior_p1;       // first hyperparameter of the beta prior
   real beta_prior_p2;       // second hyperparameter of the beta prior
   real beta_prior_p3;       // third hyperparameter of the beta prior
+  int sd_beta_prior_family;    // prior family code for the group-level beta SD
+  real sd_beta_prior_p1;       // first hyperparameter of the beta SD prior
+  real sd_beta_prior_p2;       // second hyperparameter of the beta SD prior
+  real sd_beta_prior_p3;       // third hyperparameter of the beta SD prior
 }
 parameters {
   real mu_alpha_z;              // group-level mean of alpha in unconstrained space
@@ -52,11 +60,11 @@ model {
   array[N] vector[A] Q; // per-subject action-value vectors
 
   target += prior_lpdf(mu_alpha_z | alpha_prior_family, alpha_prior_p1, alpha_prior_p2, alpha_prior_p3);
-  sd_alpha_z ~ normal(0, 1);   // half-normal prior on group SD (constrained positive)
+  target += prior_lpdf(sd_alpha_z | sd_alpha_prior_family, sd_alpha_prior_p1, sd_alpha_prior_p2, sd_alpha_prior_p3);   // configurable prior on group SD (constrained positive)
   raw_alpha_z ~ normal(0, 1);  // standard normal prior for non-centred parameterisation
 
   target += prior_lpdf(mu_beta_z | beta_prior_family, beta_prior_p1, beta_prior_p2, beta_prior_p3);
-  sd_beta_z ~ normal(0, 1);
+  target += prior_lpdf(sd_beta_z | sd_beta_prior_family, sd_beta_prior_p1, sd_beta_prior_p2, sd_beta_prior_p3);
   raw_beta_z ~ normal(0, 1);
 
   for (n in 1:N) Q[n] = rep_vector(q_init, A); // initialise Q-values for all subjects

--- a/src/comp_model/inference/bayes/stan/programs/asocial_rl_asymmetric__study_subject_block_condition_hierarchy.stan
+++ b/src/comp_model/inference/bayes/stan/programs/asocial_rl_asymmetric__study_subject_block_condition_hierarchy.stan
@@ -40,6 +40,30 @@ data {
   real beta_prior_p1;           // first hyperparameter of the beta prior
   real beta_prior_p2;           // second hyperparameter of the beta prior
   real beta_prior_p3;           // third hyperparameter of the beta prior
+  int sd_alpha_pos_prior_family;   // prior family code for the group-level shared alpha_pos SD
+  real sd_alpha_pos_prior_p1;      // first hyperparameter of the shared alpha_pos SD prior
+  real sd_alpha_pos_prior_p2;      // second hyperparameter of the shared alpha_pos SD prior
+  real sd_alpha_pos_prior_p3;      // third hyperparameter of the shared alpha_pos SD prior
+  int sd_alpha_neg_prior_family;   // prior family code for the group-level shared alpha_neg SD
+  real sd_alpha_neg_prior_p1;      // first hyperparameter of the shared alpha_neg SD prior
+  real sd_alpha_neg_prior_p2;      // second hyperparameter of the shared alpha_neg SD prior
+  real sd_alpha_neg_prior_p3;      // third hyperparameter of the shared alpha_neg SD prior
+  int sd_beta_prior_family;        // prior family code for the group-level shared beta SD
+  real sd_beta_prior_p1;           // first hyperparameter of the shared beta SD prior
+  real sd_beta_prior_p2;           // second hyperparameter of the shared beta SD prior
+  real sd_beta_prior_p3;           // third hyperparameter of the shared beta SD prior
+  int sd_alpha_pos_delta_prior_family;   // prior family code for the group-level alpha_pos delta SD
+  real sd_alpha_pos_delta_prior_p1;      // first hyperparameter of the alpha_pos delta SD prior
+  real sd_alpha_pos_delta_prior_p2;      // second hyperparameter of the alpha_pos delta SD prior
+  real sd_alpha_pos_delta_prior_p3;      // third hyperparameter of the alpha_pos delta SD prior
+  int sd_alpha_neg_delta_prior_family;   // prior family code for the group-level alpha_neg delta SD
+  real sd_alpha_neg_delta_prior_p1;      // first hyperparameter of the alpha_neg delta SD prior
+  real sd_alpha_neg_delta_prior_p2;      // second hyperparameter of the alpha_neg delta SD prior
+  real sd_alpha_neg_delta_prior_p3;      // third hyperparameter of the alpha_neg delta SD prior
+  int sd_beta_delta_prior_family;        // prior family code for the group-level beta delta SD
+  real sd_beta_delta_prior_p1;           // first hyperparameter of the beta delta SD prior
+  real sd_beta_delta_prior_p2;           // second hyperparameter of the beta delta SD prior
+  real sd_beta_delta_prior_p3;           // third hyperparameter of the beta delta SD prior
 }
 parameters {
   // Population-level: shared
@@ -106,23 +130,26 @@ model {
   array[N] vector[A] Q; // per-subject action-value vectors
 
   target += prior_lpdf(mu_alpha_pos_shared_z | alpha_pos_prior_family, alpha_pos_prior_p1, alpha_pos_prior_p2, alpha_pos_prior_p3);
-  sd_alpha_pos_shared_z ~ normal(0, 1);   // half-normal prior on group SD
+  target += prior_lpdf(sd_alpha_pos_shared_z | sd_alpha_pos_prior_family, sd_alpha_pos_prior_p1, sd_alpha_pos_prior_p2, sd_alpha_pos_prior_p3);
   raw_alpha_pos_shared_z ~ normal(0, 1);  // non-centred parameterisation
 
   target += prior_lpdf(mu_alpha_neg_shared_z | alpha_neg_prior_family, alpha_neg_prior_p1, alpha_neg_prior_p2, alpha_neg_prior_p3);
-  sd_alpha_neg_shared_z ~ normal(0, 1);
+  target += prior_lpdf(sd_alpha_neg_shared_z | sd_alpha_neg_prior_family, sd_alpha_neg_prior_p1, sd_alpha_neg_prior_p2, sd_alpha_neg_prior_p3);
   raw_alpha_neg_shared_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_beta_shared_z | beta_prior_family, beta_prior_p1, beta_prior_p2, beta_prior_p3);
-  sd_beta_shared_z ~ normal(0, 1);
+  target += prior_lpdf(sd_beta_shared_z | sd_beta_prior_family, sd_beta_prior_p1, sd_beta_prior_p2, sd_beta_prior_p3);
   raw_beta_shared_z ~ normal(0, 1);
 
   mu_alpha_pos_delta_z ~ normal(0, 1);   // regularising prior on group-level delta means
-  sd_alpha_pos_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_alpha_pos_delta_z[d] | sd_alpha_pos_delta_prior_family, sd_alpha_pos_delta_prior_p1, sd_alpha_pos_delta_prior_p2, sd_alpha_pos_delta_prior_p3);
   mu_alpha_neg_delta_z ~ normal(0, 1);
-  sd_alpha_neg_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_alpha_neg_delta_z[d] | sd_alpha_neg_delta_prior_family, sd_alpha_neg_delta_prior_p1, sd_alpha_neg_delta_prior_p2, sd_alpha_neg_delta_prior_p3);
   mu_beta_delta_z ~ normal(0, 1);
-  sd_beta_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_beta_delta_z[d] | sd_beta_delta_prior_family, sd_beta_delta_prior_p1, sd_beta_delta_prior_p2, sd_beta_delta_prior_p3);
   for (d in 1:(C - 1)) {
     raw_alpha_pos_delta_z[d] ~ normal(0, 1); // non-centred deviates for per-subject alpha_pos deltas
     raw_alpha_neg_delta_z[d] ~ normal(0, 1);

--- a/src/comp_model/inference/bayes/stan/programs/asocial_rl_asymmetric__study_subject_hierarchy.stan
+++ b/src/comp_model/inference/bayes/stan/programs/asocial_rl_asymmetric__study_subject_hierarchy.stan
@@ -28,14 +28,26 @@ data {
   real alpha_pos_prior_p1;      // first hyperparameter of the alpha_pos prior
   real alpha_pos_prior_p2;      // second hyperparameter of the alpha_pos prior
   real alpha_pos_prior_p3;      // third hyperparameter of the alpha_pos prior
+  int sd_alpha_pos_prior_family;   // prior family code for the group-level alpha_pos SD
+  real sd_alpha_pos_prior_p1;      // first hyperparameter of the alpha_pos SD prior
+  real sd_alpha_pos_prior_p2;      // second hyperparameter of the alpha_pos SD prior
+  real sd_alpha_pos_prior_p3;      // third hyperparameter of the alpha_pos SD prior
   int alpha_neg_prior_family;   // prior family code for the group-level alpha_neg mean
   real alpha_neg_prior_p1;      // first hyperparameter of the alpha_neg prior
   real alpha_neg_prior_p2;      // second hyperparameter of the alpha_neg prior
   real alpha_neg_prior_p3;      // third hyperparameter of the alpha_neg prior
+  int sd_alpha_neg_prior_family;   // prior family code for the group-level alpha_neg SD
+  real sd_alpha_neg_prior_p1;      // first hyperparameter of the alpha_neg SD prior
+  real sd_alpha_neg_prior_p2;      // second hyperparameter of the alpha_neg SD prior
+  real sd_alpha_neg_prior_p3;      // third hyperparameter of the alpha_neg SD prior
   int beta_prior_family;        // prior family code for the group-level beta mean
   real beta_prior_p1;           // first hyperparameter of the beta prior
   real beta_prior_p2;           // second hyperparameter of the beta prior
   real beta_prior_p3;           // third hyperparameter of the beta prior
+  int sd_beta_prior_family;        // prior family code for the group-level beta SD
+  real sd_beta_prior_p1;           // first hyperparameter of the beta SD prior
+  real sd_beta_prior_p2;           // second hyperparameter of the beta SD prior
+  real sd_beta_prior_p3;           // third hyperparameter of the beta SD prior
 }
 parameters {
   real mu_alpha_pos_z;              // group-level mean of alpha_pos in unconstrained space
@@ -62,15 +74,15 @@ model {
   array[N] vector[A] Q; // per-subject action-value vectors
 
   target += prior_lpdf(mu_alpha_pos_z | alpha_pos_prior_family, alpha_pos_prior_p1, alpha_pos_prior_p2, alpha_pos_prior_p3);
-  sd_alpha_pos_z ~ normal(0, 1);  // half-normal prior on group SD
+  target += prior_lpdf(sd_alpha_pos_z | sd_alpha_pos_prior_family, sd_alpha_pos_prior_p1, sd_alpha_pos_prior_p2, sd_alpha_pos_prior_p3);  // configurable prior on group SD (constrained positive)
   raw_alpha_pos_z ~ normal(0, 1); // non-centred parameterisation
 
   target += prior_lpdf(mu_alpha_neg_z | alpha_neg_prior_family, alpha_neg_prior_p1, alpha_neg_prior_p2, alpha_neg_prior_p3);
-  sd_alpha_neg_z ~ normal(0, 1);
+  target += prior_lpdf(sd_alpha_neg_z | sd_alpha_neg_prior_family, sd_alpha_neg_prior_p1, sd_alpha_neg_prior_p2, sd_alpha_neg_prior_p3);
   raw_alpha_neg_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_beta_z | beta_prior_family, beta_prior_p1, beta_prior_p2, beta_prior_p3);
-  sd_beta_z ~ normal(0, 1);
+  target += prior_lpdf(sd_beta_z | sd_beta_prior_family, sd_beta_prior_p1, sd_beta_prior_p2, sd_beta_prior_p3);
   raw_beta_z ~ normal(0, 1);
 
   for (n in 1:N) Q[n] = rep_vector(q_init, A); // initialise Q-values for all subjects

--- a/src/comp_model/inference/bayes/stan/programs/social_rl_demo_mixture__study_subject_block_condition_hierarchy.stan
+++ b/src/comp_model/inference/bayes/stan/programs/social_rl_demo_mixture__study_subject_block_condition_hierarchy.stan
@@ -49,6 +49,38 @@ data {
   real beta_prior_p1;                     // first hyperparameter of the beta prior
   real beta_prior_p2;                     // second hyperparameter of the beta prior
   real beta_prior_p3;                     // third hyperparameter of the beta prior
+  int sd_alpha_other_outcome_prior_family;   // prior family code for the group-level shared alpha_other_outcome SD
+  real sd_alpha_other_outcome_prior_p1;      // first hyperparameter of the shared alpha_other_outcome SD prior
+  real sd_alpha_other_outcome_prior_p2;      // second hyperparameter of the shared alpha_other_outcome SD prior
+  real sd_alpha_other_outcome_prior_p3;      // third hyperparameter of the shared alpha_other_outcome SD prior
+  int sd_alpha_other_action_prior_family;    // prior family code for the group-level shared alpha_other_action SD
+  real sd_alpha_other_action_prior_p1;       // first hyperparameter of the shared alpha_other_action SD prior
+  real sd_alpha_other_action_prior_p2;       // second hyperparameter of the shared alpha_other_action SD prior
+  real sd_alpha_other_action_prior_p3;       // third hyperparameter of the shared alpha_other_action SD prior
+  int sd_w_imitation_prior_family;           // prior family code for the group-level shared w_imitation SD
+  real sd_w_imitation_prior_p1;              // first hyperparameter of the shared w_imitation SD prior
+  real sd_w_imitation_prior_p2;              // second hyperparameter of the shared w_imitation SD prior
+  real sd_w_imitation_prior_p3;              // third hyperparameter of the shared w_imitation SD prior
+  int sd_beta_prior_family;                  // prior family code for the group-level shared beta SD
+  real sd_beta_prior_p1;                     // first hyperparameter of the shared beta SD prior
+  real sd_beta_prior_p2;                     // second hyperparameter of the shared beta SD prior
+  real sd_beta_prior_p3;                     // third hyperparameter of the shared beta SD prior
+  int sd_alpha_other_outcome_delta_prior_family;   // prior family code for the group-level alpha_other_outcome delta SD
+  real sd_alpha_other_outcome_delta_prior_p1;      // first hyperparameter of the alpha_other_outcome delta SD prior
+  real sd_alpha_other_outcome_delta_prior_p2;      // second hyperparameter of the alpha_other_outcome delta SD prior
+  real sd_alpha_other_outcome_delta_prior_p3;      // third hyperparameter of the alpha_other_outcome delta SD prior
+  int sd_alpha_other_action_delta_prior_family;    // prior family code for the group-level alpha_other_action delta SD
+  real sd_alpha_other_action_delta_prior_p1;       // first hyperparameter of the alpha_other_action delta SD prior
+  real sd_alpha_other_action_delta_prior_p2;       // second hyperparameter of the alpha_other_action delta SD prior
+  real sd_alpha_other_action_delta_prior_p3;       // third hyperparameter of the alpha_other_action delta SD prior
+  int sd_w_imitation_delta_prior_family;           // prior family code for the group-level w_imitation delta SD
+  real sd_w_imitation_delta_prior_p1;              // first hyperparameter of the w_imitation delta SD prior
+  real sd_w_imitation_delta_prior_p2;              // second hyperparameter of the w_imitation delta SD prior
+  real sd_w_imitation_delta_prior_p3;              // third hyperparameter of the w_imitation delta SD prior
+  int sd_beta_delta_prior_family;                  // prior family code for the group-level beta delta SD
+  real sd_beta_delta_prior_p1;                     // first hyperparameter of the beta delta SD prior
+  real sd_beta_delta_prior_p2;                     // second hyperparameter of the beta delta SD prior
+  real sd_beta_delta_prior_p3;                     // third hyperparameter of the beta delta SD prior
 }
 parameters {
   // Population-level: shared (baseline)
@@ -133,30 +165,34 @@ model {
 
   // Priors: shared (baseline)
   target += prior_lpdf(mu_alpha_other_outcome_shared_z | alpha_other_outcome_prior_family, alpha_other_outcome_prior_p1, alpha_other_outcome_prior_p2, alpha_other_outcome_prior_p3);
-  sd_alpha_other_outcome_shared_z ~ normal(0, 1);
+  target += prior_lpdf(sd_alpha_other_outcome_shared_z | sd_alpha_other_outcome_prior_family, sd_alpha_other_outcome_prior_p1, sd_alpha_other_outcome_prior_p2, sd_alpha_other_outcome_prior_p3);
   raw_alpha_other_outcome_shared_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_alpha_other_action_shared_z | alpha_other_action_prior_family, alpha_other_action_prior_p1, alpha_other_action_prior_p2, alpha_other_action_prior_p3);
-  sd_alpha_other_action_shared_z ~ normal(0, 1);
+  target += prior_lpdf(sd_alpha_other_action_shared_z | sd_alpha_other_action_prior_family, sd_alpha_other_action_prior_p1, sd_alpha_other_action_prior_p2, sd_alpha_other_action_prior_p3);
   raw_alpha_other_action_shared_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_w_imitation_shared_z | w_imitation_prior_family, w_imitation_prior_p1, w_imitation_prior_p2, w_imitation_prior_p3);
-  sd_w_imitation_shared_z ~ normal(0, 1);
+  target += prior_lpdf(sd_w_imitation_shared_z | sd_w_imitation_prior_family, sd_w_imitation_prior_p1, sd_w_imitation_prior_p2, sd_w_imitation_prior_p3);
   raw_w_imitation_shared_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_beta_shared_z | beta_prior_family, beta_prior_p1, beta_prior_p2, beta_prior_p3);
-  sd_beta_shared_z ~ normal(0, 1);
+  target += prior_lpdf(sd_beta_shared_z | sd_beta_prior_family, sd_beta_prior_p1, sd_beta_prior_p2, sd_beta_prior_p3);
   raw_beta_shared_z ~ normal(0, 1);
 
-  // Priors: condition deltas (regularising; not passed as data)
+  // Priors: condition deltas
   mu_alpha_other_outcome_delta_z ~ normal(0, 1);
-  sd_alpha_other_outcome_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_alpha_other_outcome_delta_z[d] | sd_alpha_other_outcome_delta_prior_family, sd_alpha_other_outcome_delta_prior_p1, sd_alpha_other_outcome_delta_prior_p2, sd_alpha_other_outcome_delta_prior_p3);
   mu_alpha_other_action_delta_z ~ normal(0, 1);
-  sd_alpha_other_action_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_alpha_other_action_delta_z[d] | sd_alpha_other_action_delta_prior_family, sd_alpha_other_action_delta_prior_p1, sd_alpha_other_action_delta_prior_p2, sd_alpha_other_action_delta_prior_p3);
   mu_w_imitation_delta_z ~ normal(0, 1);
-  sd_w_imitation_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_w_imitation_delta_z[d] | sd_w_imitation_delta_prior_family, sd_w_imitation_delta_prior_p1, sd_w_imitation_delta_prior_p2, sd_w_imitation_delta_prior_p3);
   mu_beta_delta_z ~ normal(0, 1);
-  sd_beta_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_beta_delta_z[d] | sd_beta_delta_prior_family, sd_beta_delta_prior_p1, sd_beta_delta_prior_p2, sd_beta_delta_prior_p3);
   for (d in 1:(C - 1)) {
     raw_alpha_other_outcome_delta_z[d] ~ normal(0, 1);
     raw_alpha_other_action_delta_z[d] ~ normal(0, 1);

--- a/src/comp_model/inference/bayes/stan/programs/social_rl_demo_mixture__study_subject_hierarchy.stan
+++ b/src/comp_model/inference/bayes/stan/programs/social_rl_demo_mixture__study_subject_hierarchy.stan
@@ -33,18 +33,34 @@ data {
   real alpha_other_outcome_prior_p1;      // first hyperparameter of the alpha_other_outcome prior
   real alpha_other_outcome_prior_p2;      // second hyperparameter of the alpha_other_outcome prior
   real alpha_other_outcome_prior_p3;      // third hyperparameter of the alpha_other_outcome prior
+  int sd_alpha_other_outcome_prior_family;   // prior family code for the group-level alpha_other_outcome SD
+  real sd_alpha_other_outcome_prior_p1;      // first hyperparameter of the alpha_other_outcome SD prior
+  real sd_alpha_other_outcome_prior_p2;      // second hyperparameter of the alpha_other_outcome SD prior
+  real sd_alpha_other_outcome_prior_p3;      // third hyperparameter of the alpha_other_outcome SD prior
   int alpha_other_action_prior_family;    // prior family code for the group-level alpha_other_action mean
   real alpha_other_action_prior_p1;       // first hyperparameter of the alpha_other_action prior
   real alpha_other_action_prior_p2;       // second hyperparameter of the alpha_other_action prior
   real alpha_other_action_prior_p3;       // third hyperparameter of the alpha_other_action prior
+  int sd_alpha_other_action_prior_family;    // prior family code for the group-level alpha_other_action SD
+  real sd_alpha_other_action_prior_p1;       // first hyperparameter of the alpha_other_action SD prior
+  real sd_alpha_other_action_prior_p2;       // second hyperparameter of the alpha_other_action SD prior
+  real sd_alpha_other_action_prior_p3;       // third hyperparameter of the alpha_other_action SD prior
   int w_imitation_prior_family;           // prior family code for the group-level w_imitation mean
   real w_imitation_prior_p1;              // first hyperparameter of the w_imitation prior
   real w_imitation_prior_p2;              // second hyperparameter of the w_imitation prior
   real w_imitation_prior_p3;              // third hyperparameter of the w_imitation prior
+  int sd_w_imitation_prior_family;           // prior family code for the group-level w_imitation SD
+  real sd_w_imitation_prior_p1;              // first hyperparameter of the w_imitation SD prior
+  real sd_w_imitation_prior_p2;              // second hyperparameter of the w_imitation SD prior
+  real sd_w_imitation_prior_p3;              // third hyperparameter of the w_imitation SD prior
   int beta_prior_family;                  // prior family code for the group-level beta mean
   real beta_prior_p1;                     // first hyperparameter of the beta prior
   real beta_prior_p2;                     // second hyperparameter of the beta prior
   real beta_prior_p3;                     // third hyperparameter of the beta prior
+  int sd_beta_prior_family;                  // prior family code for the group-level beta SD
+  real sd_beta_prior_p1;                     // first hyperparameter of the beta SD prior
+  real sd_beta_prior_p2;                     // second hyperparameter of the beta SD prior
+  real sd_beta_prior_p3;                     // third hyperparameter of the beta SD prior
 }
 parameters {
   real mu_alpha_other_outcome_z;          // group-level mean of alpha_other_outcome in unconstrained space
@@ -79,19 +95,19 @@ model {
   array[N] vector[A] T; // per-subject action-tendency vectors
 
   target += prior_lpdf(mu_alpha_other_outcome_z | alpha_other_outcome_prior_family, alpha_other_outcome_prior_p1, alpha_other_outcome_prior_p2, alpha_other_outcome_prior_p3);
-  sd_alpha_other_outcome_z ~ normal(0, 1);
+  target += prior_lpdf(sd_alpha_other_outcome_z | sd_alpha_other_outcome_prior_family, sd_alpha_other_outcome_prior_p1, sd_alpha_other_outcome_prior_p2, sd_alpha_other_outcome_prior_p3);   // configurable prior on group SD (constrained positive)
   raw_alpha_other_outcome_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_alpha_other_action_z | alpha_other_action_prior_family, alpha_other_action_prior_p1, alpha_other_action_prior_p2, alpha_other_action_prior_p3);
-  sd_alpha_other_action_z ~ normal(0, 1);
+  target += prior_lpdf(sd_alpha_other_action_z | sd_alpha_other_action_prior_family, sd_alpha_other_action_prior_p1, sd_alpha_other_action_prior_p2, sd_alpha_other_action_prior_p3);
   raw_alpha_other_action_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_w_imitation_z | w_imitation_prior_family, w_imitation_prior_p1, w_imitation_prior_p2, w_imitation_prior_p3);
-  sd_w_imitation_z ~ normal(0, 1);
+  target += prior_lpdf(sd_w_imitation_z | sd_w_imitation_prior_family, sd_w_imitation_prior_p1, sd_w_imitation_prior_p2, sd_w_imitation_prior_p3);
   raw_w_imitation_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_beta_z | beta_prior_family, beta_prior_p1, beta_prior_p2, beta_prior_p3);
-  sd_beta_z ~ normal(0, 1);
+  target += prior_lpdf(sd_beta_z | sd_beta_prior_family, sd_beta_prior_p1, sd_beta_prior_p2, sd_beta_prior_p3);
   raw_beta_z ~ normal(0, 1);
 
   for (n in 1:N) Q[n] = rep_vector(q_init, A);      // initialise outcome-values for all subjects

--- a/src/comp_model/inference/bayes/stan/programs/social_rl_self_reward_demo_action_mixture__study_subject_block_condition_hierarchy.stan
+++ b/src/comp_model/inference/bayes/stan/programs/social_rl_self_reward_demo_action_mixture__study_subject_block_condition_hierarchy.stan
@@ -49,6 +49,38 @@ data {
   real beta_prior_p1;                     // first hyperparameter of the beta prior
   real beta_prior_p2;                     // second hyperparameter of the beta prior
   real beta_prior_p3;                     // third hyperparameter of the beta prior
+  int sd_alpha_self_prior_family;            // prior family code for the group-level shared alpha_self SD
+  real sd_alpha_self_prior_p1;               // first hyperparameter of the shared alpha_self SD prior
+  real sd_alpha_self_prior_p2;               // second hyperparameter of the shared alpha_self SD prior
+  real sd_alpha_self_prior_p3;               // third hyperparameter of the shared alpha_self SD prior
+  int sd_alpha_other_action_prior_family;    // prior family code for the group-level shared alpha_other_action SD
+  real sd_alpha_other_action_prior_p1;       // first hyperparameter of the shared alpha_other_action SD prior
+  real sd_alpha_other_action_prior_p2;       // second hyperparameter of the shared alpha_other_action SD prior
+  real sd_alpha_other_action_prior_p3;       // third hyperparameter of the shared alpha_other_action SD prior
+  int sd_w_imitation_prior_family;           // prior family code for the group-level shared w_imitation SD
+  real sd_w_imitation_prior_p1;              // first hyperparameter of the shared w_imitation SD prior
+  real sd_w_imitation_prior_p2;              // second hyperparameter of the shared w_imitation SD prior
+  real sd_w_imitation_prior_p3;              // third hyperparameter of the shared w_imitation SD prior
+  int sd_beta_prior_family;                  // prior family code for the group-level shared beta SD
+  real sd_beta_prior_p1;                     // first hyperparameter of the shared beta SD prior
+  real sd_beta_prior_p2;                     // second hyperparameter of the shared beta SD prior
+  real sd_beta_prior_p3;                     // third hyperparameter of the shared beta SD prior
+  int sd_alpha_self_delta_prior_family;            // prior family code for the group-level alpha_self delta SD
+  real sd_alpha_self_delta_prior_p1;               // first hyperparameter of the alpha_self delta SD prior
+  real sd_alpha_self_delta_prior_p2;               // second hyperparameter of the alpha_self delta SD prior
+  real sd_alpha_self_delta_prior_p3;               // third hyperparameter of the alpha_self delta SD prior
+  int sd_alpha_other_action_delta_prior_family;    // prior family code for the group-level alpha_other_action delta SD
+  real sd_alpha_other_action_delta_prior_p1;       // first hyperparameter of the alpha_other_action delta SD prior
+  real sd_alpha_other_action_delta_prior_p2;       // second hyperparameter of the alpha_other_action delta SD prior
+  real sd_alpha_other_action_delta_prior_p3;       // third hyperparameter of the alpha_other_action delta SD prior
+  int sd_w_imitation_delta_prior_family;           // prior family code for the group-level w_imitation delta SD
+  real sd_w_imitation_delta_prior_p1;              // first hyperparameter of the w_imitation delta SD prior
+  real sd_w_imitation_delta_prior_p2;              // second hyperparameter of the w_imitation delta SD prior
+  real sd_w_imitation_delta_prior_p3;              // third hyperparameter of the w_imitation delta SD prior
+  int sd_beta_delta_prior_family;                  // prior family code for the group-level beta delta SD
+  real sd_beta_delta_prior_p1;                     // first hyperparameter of the beta delta SD prior
+  real sd_beta_delta_prior_p2;                     // second hyperparameter of the beta delta SD prior
+  real sd_beta_delta_prior_p3;                     // third hyperparameter of the beta delta SD prior
 }
 parameters {
   // Population-level: shared (baseline)
@@ -133,30 +165,34 @@ model {
 
   // Priors: shared (baseline)
   target += prior_lpdf(mu_alpha_self_shared_z | alpha_self_prior_family, alpha_self_prior_p1, alpha_self_prior_p2, alpha_self_prior_p3);
-  sd_alpha_self_shared_z ~ normal(0, 1);   // half-normal prior on group SD
+  target += prior_lpdf(sd_alpha_self_shared_z | sd_alpha_self_prior_family, sd_alpha_self_prior_p1, sd_alpha_self_prior_p2, sd_alpha_self_prior_p3);
   raw_alpha_self_shared_z ~ normal(0, 1);  // non-centred parameterisation
 
   target += prior_lpdf(mu_alpha_other_action_shared_z | alpha_other_action_prior_family, alpha_other_action_prior_p1, alpha_other_action_prior_p2, alpha_other_action_prior_p3);
-  sd_alpha_other_action_shared_z ~ normal(0, 1);
+  target += prior_lpdf(sd_alpha_other_action_shared_z | sd_alpha_other_action_prior_family, sd_alpha_other_action_prior_p1, sd_alpha_other_action_prior_p2, sd_alpha_other_action_prior_p3);
   raw_alpha_other_action_shared_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_w_imitation_shared_z | w_imitation_prior_family, w_imitation_prior_p1, w_imitation_prior_p2, w_imitation_prior_p3);
-  sd_w_imitation_shared_z ~ normal(0, 1);
+  target += prior_lpdf(sd_w_imitation_shared_z | sd_w_imitation_prior_family, sd_w_imitation_prior_p1, sd_w_imitation_prior_p2, sd_w_imitation_prior_p3);
   raw_w_imitation_shared_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_beta_shared_z | beta_prior_family, beta_prior_p1, beta_prior_p2, beta_prior_p3);
-  sd_beta_shared_z ~ normal(0, 1);
+  target += prior_lpdf(sd_beta_shared_z | sd_beta_prior_family, sd_beta_prior_p1, sd_beta_prior_p2, sd_beta_prior_p3);
   raw_beta_shared_z ~ normal(0, 1);
 
-  // Priors: condition deltas (regularising; not passed as data)
+  // Priors: condition deltas
   mu_alpha_self_delta_z ~ normal(0, 1);
-  sd_alpha_self_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_alpha_self_delta_z[d] | sd_alpha_self_delta_prior_family, sd_alpha_self_delta_prior_p1, sd_alpha_self_delta_prior_p2, sd_alpha_self_delta_prior_p3);
   mu_alpha_other_action_delta_z ~ normal(0, 1);
-  sd_alpha_other_action_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_alpha_other_action_delta_z[d] | sd_alpha_other_action_delta_prior_family, sd_alpha_other_action_delta_prior_p1, sd_alpha_other_action_delta_prior_p2, sd_alpha_other_action_delta_prior_p3);
   mu_w_imitation_delta_z ~ normal(0, 1);
-  sd_w_imitation_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_w_imitation_delta_z[d] | sd_w_imitation_delta_prior_family, sd_w_imitation_delta_prior_p1, sd_w_imitation_delta_prior_p2, sd_w_imitation_delta_prior_p3);
   mu_beta_delta_z ~ normal(0, 1);
-  sd_beta_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_beta_delta_z[d] | sd_beta_delta_prior_family, sd_beta_delta_prior_p1, sd_beta_delta_prior_p2, sd_beta_delta_prior_p3);
   for (d in 1:(C - 1)) {
     raw_alpha_self_delta_z[d] ~ normal(0, 1);          // non-centred deviates for per-subject alpha_self deltas
     raw_alpha_other_action_delta_z[d] ~ normal(0, 1);

--- a/src/comp_model/inference/bayes/stan/programs/social_rl_self_reward_demo_action_mixture__study_subject_hierarchy.stan
+++ b/src/comp_model/inference/bayes/stan/programs/social_rl_self_reward_demo_action_mixture__study_subject_hierarchy.stan
@@ -33,18 +33,34 @@ data {
   real alpha_self_prior_p1;               // first hyperparameter of the alpha_self prior
   real alpha_self_prior_p2;               // second hyperparameter of the alpha_self prior
   real alpha_self_prior_p3;               // third hyperparameter of the alpha_self prior
+  int sd_alpha_self_prior_family;            // prior family code for the group-level alpha_self SD
+  real sd_alpha_self_prior_p1;               // first hyperparameter of the alpha_self SD prior
+  real sd_alpha_self_prior_p2;               // second hyperparameter of the alpha_self SD prior
+  real sd_alpha_self_prior_p3;               // third hyperparameter of the alpha_self SD prior
   int alpha_other_action_prior_family;    // prior family code for the group-level alpha_other_action mean
   real alpha_other_action_prior_p1;       // first hyperparameter of the alpha_other_action prior
   real alpha_other_action_prior_p2;       // second hyperparameter of the alpha_other_action prior
   real alpha_other_action_prior_p3;       // third hyperparameter of the alpha_other_action prior
+  int sd_alpha_other_action_prior_family;    // prior family code for the group-level alpha_other_action SD
+  real sd_alpha_other_action_prior_p1;       // first hyperparameter of the alpha_other_action SD prior
+  real sd_alpha_other_action_prior_p2;       // second hyperparameter of the alpha_other_action SD prior
+  real sd_alpha_other_action_prior_p3;       // third hyperparameter of the alpha_other_action SD prior
   int w_imitation_prior_family;           // prior family code for the group-level w_imitation mean
   real w_imitation_prior_p1;              // first hyperparameter of the w_imitation prior
   real w_imitation_prior_p2;              // second hyperparameter of the w_imitation prior
   real w_imitation_prior_p3;              // third hyperparameter of the w_imitation prior
+  int sd_w_imitation_prior_family;           // prior family code for the group-level w_imitation SD
+  real sd_w_imitation_prior_p1;              // first hyperparameter of the w_imitation SD prior
+  real sd_w_imitation_prior_p2;              // second hyperparameter of the w_imitation SD prior
+  real sd_w_imitation_prior_p3;              // third hyperparameter of the w_imitation SD prior
   int beta_prior_family;                  // prior family code for the group-level beta mean
   real beta_prior_p1;                     // first hyperparameter of the beta prior
   real beta_prior_p2;                     // second hyperparameter of the beta prior
   real beta_prior_p3;                     // third hyperparameter of the beta prior
+  int sd_beta_prior_family;                  // prior family code for the group-level beta SD
+  real sd_beta_prior_p1;                     // first hyperparameter of the beta SD prior
+  real sd_beta_prior_p2;                     // second hyperparameter of the beta SD prior
+  real sd_beta_prior_p3;                     // third hyperparameter of the beta SD prior
 }
 parameters {
   real mu_alpha_self_z;                   // group-level mean of alpha_self in unconstrained space
@@ -79,19 +95,19 @@ model {
   array[N] vector[A] T; // per-subject action-tendency vectors
 
   target += prior_lpdf(mu_alpha_self_z | alpha_self_prior_family, alpha_self_prior_p1, alpha_self_prior_p2, alpha_self_prior_p3);
-  sd_alpha_self_z ~ normal(0, 1);   // half-normal prior on group SD
+  target += prior_lpdf(sd_alpha_self_z | sd_alpha_self_prior_family, sd_alpha_self_prior_p1, sd_alpha_self_prior_p2, sd_alpha_self_prior_p3);   // configurable prior on group SD (constrained positive)
   raw_alpha_self_z ~ normal(0, 1);  // non-centred parameterisation
 
   target += prior_lpdf(mu_alpha_other_action_z | alpha_other_action_prior_family, alpha_other_action_prior_p1, alpha_other_action_prior_p2, alpha_other_action_prior_p3);
-  sd_alpha_other_action_z ~ normal(0, 1);
+  target += prior_lpdf(sd_alpha_other_action_z | sd_alpha_other_action_prior_family, sd_alpha_other_action_prior_p1, sd_alpha_other_action_prior_p2, sd_alpha_other_action_prior_p3);
   raw_alpha_other_action_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_w_imitation_z | w_imitation_prior_family, w_imitation_prior_p1, w_imitation_prior_p2, w_imitation_prior_p3);
-  sd_w_imitation_z ~ normal(0, 1);
+  target += prior_lpdf(sd_w_imitation_z | sd_w_imitation_prior_family, sd_w_imitation_prior_p1, sd_w_imitation_prior_p2, sd_w_imitation_prior_p3);
   raw_w_imitation_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_beta_z | beta_prior_family, beta_prior_p1, beta_prior_p2, beta_prior_p3);
-  sd_beta_z ~ normal(0, 1);
+  target += prior_lpdf(sd_beta_z | sd_beta_prior_family, sd_beta_prior_p1, sd_beta_prior_p2, sd_beta_prior_p3);
   raw_beta_z ~ normal(0, 1);
 
   for (n in 1:N) Q[n] = rep_vector(q_init, A);      // initialise outcome-values for all subjects

--- a/src/comp_model/inference/bayes/stan/programs/social_rl_self_reward_demo_mixture__study_subject_block_condition_hierarchy.stan
+++ b/src/comp_model/inference/bayes/stan/programs/social_rl_self_reward_demo_mixture__study_subject_block_condition_hierarchy.stan
@@ -53,6 +53,46 @@ data {
   real beta_prior_p1;                     // first hyperparameter of the beta prior
   real beta_prior_p2;                     // second hyperparameter of the beta prior
   real beta_prior_p3;                     // third hyperparameter of the beta prior
+  int sd_alpha_self_prior_family;            // prior family code for the group-level shared alpha_self SD
+  real sd_alpha_self_prior_p1;               // first hyperparameter of the shared alpha_self SD prior
+  real sd_alpha_self_prior_p2;               // second hyperparameter of the shared alpha_self SD prior
+  real sd_alpha_self_prior_p3;               // third hyperparameter of the shared alpha_self SD prior
+  int sd_alpha_other_outcome_prior_family;   // prior family code for the group-level shared alpha_other_outcome SD
+  real sd_alpha_other_outcome_prior_p1;      // first hyperparameter of the shared alpha_other_outcome SD prior
+  real sd_alpha_other_outcome_prior_p2;      // second hyperparameter of the shared alpha_other_outcome SD prior
+  real sd_alpha_other_outcome_prior_p3;      // third hyperparameter of the shared alpha_other_outcome SD prior
+  int sd_alpha_other_action_prior_family;    // prior family code for the group-level shared alpha_other_action SD
+  real sd_alpha_other_action_prior_p1;       // first hyperparameter of the shared alpha_other_action SD prior
+  real sd_alpha_other_action_prior_p2;       // second hyperparameter of the shared alpha_other_action SD prior
+  real sd_alpha_other_action_prior_p3;       // third hyperparameter of the shared alpha_other_action SD prior
+  int sd_w_imitation_prior_family;           // prior family code for the group-level shared w_imitation SD
+  real sd_w_imitation_prior_p1;              // first hyperparameter of the shared w_imitation SD prior
+  real sd_w_imitation_prior_p2;              // second hyperparameter of the shared w_imitation SD prior
+  real sd_w_imitation_prior_p3;              // third hyperparameter of the shared w_imitation SD prior
+  int sd_beta_prior_family;                  // prior family code for the group-level shared beta SD
+  real sd_beta_prior_p1;                     // first hyperparameter of the shared beta SD prior
+  real sd_beta_prior_p2;                     // second hyperparameter of the shared beta SD prior
+  real sd_beta_prior_p3;                     // third hyperparameter of the shared beta SD prior
+  int sd_alpha_self_delta_prior_family;            // prior family code for the group-level alpha_self delta SD
+  real sd_alpha_self_delta_prior_p1;               // first hyperparameter of the alpha_self delta SD prior
+  real sd_alpha_self_delta_prior_p2;               // second hyperparameter of the alpha_self delta SD prior
+  real sd_alpha_self_delta_prior_p3;               // third hyperparameter of the alpha_self delta SD prior
+  int sd_alpha_other_outcome_delta_prior_family;   // prior family code for the group-level alpha_other_outcome delta SD
+  real sd_alpha_other_outcome_delta_prior_p1;      // first hyperparameter of the alpha_other_outcome delta SD prior
+  real sd_alpha_other_outcome_delta_prior_p2;      // second hyperparameter of the alpha_other_outcome delta SD prior
+  real sd_alpha_other_outcome_delta_prior_p3;      // third hyperparameter of the alpha_other_outcome delta SD prior
+  int sd_alpha_other_action_delta_prior_family;    // prior family code for the group-level alpha_other_action delta SD
+  real sd_alpha_other_action_delta_prior_p1;       // first hyperparameter of the alpha_other_action delta SD prior
+  real sd_alpha_other_action_delta_prior_p2;       // second hyperparameter of the alpha_other_action delta SD prior
+  real sd_alpha_other_action_delta_prior_p3;       // third hyperparameter of the alpha_other_action delta SD prior
+  int sd_w_imitation_delta_prior_family;           // prior family code for the group-level w_imitation delta SD
+  real sd_w_imitation_delta_prior_p1;              // first hyperparameter of the w_imitation delta SD prior
+  real sd_w_imitation_delta_prior_p2;              // second hyperparameter of the w_imitation delta SD prior
+  real sd_w_imitation_delta_prior_p3;              // third hyperparameter of the w_imitation delta SD prior
+  int sd_beta_delta_prior_family;                  // prior family code for the group-level beta delta SD
+  real sd_beta_delta_prior_p1;                     // first hyperparameter of the beta delta SD prior
+  real sd_beta_delta_prior_p2;                     // second hyperparameter of the beta delta SD prior
+  real sd_beta_delta_prior_p3;                     // third hyperparameter of the beta delta SD prior
 }
 parameters {
   // Population-level: shared (baseline)
@@ -150,36 +190,41 @@ model {
 
   // Priors: shared (baseline)
   target += prior_lpdf(mu_alpha_self_shared_z | alpha_self_prior_family, alpha_self_prior_p1, alpha_self_prior_p2, alpha_self_prior_p3);
-  sd_alpha_self_shared_z ~ normal(0, 1);   // half-normal prior on group SD
+  target += prior_lpdf(sd_alpha_self_shared_z | sd_alpha_self_prior_family, sd_alpha_self_prior_p1, sd_alpha_self_prior_p2, sd_alpha_self_prior_p3);
   raw_alpha_self_shared_z ~ normal(0, 1);  // non-centred parameterisation
 
   target += prior_lpdf(mu_alpha_other_outcome_shared_z | alpha_other_outcome_prior_family, alpha_other_outcome_prior_p1, alpha_other_outcome_prior_p2, alpha_other_outcome_prior_p3);
-  sd_alpha_other_outcome_shared_z ~ normal(0, 1);
+  target += prior_lpdf(sd_alpha_other_outcome_shared_z | sd_alpha_other_outcome_prior_family, sd_alpha_other_outcome_prior_p1, sd_alpha_other_outcome_prior_p2, sd_alpha_other_outcome_prior_p3);
   raw_alpha_other_outcome_shared_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_alpha_other_action_shared_z | alpha_other_action_prior_family, alpha_other_action_prior_p1, alpha_other_action_prior_p2, alpha_other_action_prior_p3);
-  sd_alpha_other_action_shared_z ~ normal(0, 1);
+  target += prior_lpdf(sd_alpha_other_action_shared_z | sd_alpha_other_action_prior_family, sd_alpha_other_action_prior_p1, sd_alpha_other_action_prior_p2, sd_alpha_other_action_prior_p3);
   raw_alpha_other_action_shared_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_w_imitation_shared_z | w_imitation_prior_family, w_imitation_prior_p1, w_imitation_prior_p2, w_imitation_prior_p3);
-  sd_w_imitation_shared_z ~ normal(0, 1);
+  target += prior_lpdf(sd_w_imitation_shared_z | sd_w_imitation_prior_family, sd_w_imitation_prior_p1, sd_w_imitation_prior_p2, sd_w_imitation_prior_p3);
   raw_w_imitation_shared_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_beta_shared_z | beta_prior_family, beta_prior_p1, beta_prior_p2, beta_prior_p3);
-  sd_beta_shared_z ~ normal(0, 1);
+  target += prior_lpdf(sd_beta_shared_z | sd_beta_prior_family, sd_beta_prior_p1, sd_beta_prior_p2, sd_beta_prior_p3);
   raw_beta_shared_z ~ normal(0, 1);
 
-  // Priors: condition deltas (regularising; not passed as data)
+  // Priors: condition deltas
   mu_alpha_self_delta_z ~ normal(0, 1);
-  sd_alpha_self_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_alpha_self_delta_z[d] | sd_alpha_self_delta_prior_family, sd_alpha_self_delta_prior_p1, sd_alpha_self_delta_prior_p2, sd_alpha_self_delta_prior_p3);
   mu_alpha_other_outcome_delta_z ~ normal(0, 1);
-  sd_alpha_other_outcome_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_alpha_other_outcome_delta_z[d] | sd_alpha_other_outcome_delta_prior_family, sd_alpha_other_outcome_delta_prior_p1, sd_alpha_other_outcome_delta_prior_p2, sd_alpha_other_outcome_delta_prior_p3);
   mu_alpha_other_action_delta_z ~ normal(0, 1);
-  sd_alpha_other_action_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_alpha_other_action_delta_z[d] | sd_alpha_other_action_delta_prior_family, sd_alpha_other_action_delta_prior_p1, sd_alpha_other_action_delta_prior_p2, sd_alpha_other_action_delta_prior_p3);
   mu_w_imitation_delta_z ~ normal(0, 1);
-  sd_w_imitation_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_w_imitation_delta_z[d] | sd_w_imitation_delta_prior_family, sd_w_imitation_delta_prior_p1, sd_w_imitation_delta_prior_p2, sd_w_imitation_delta_prior_p3);
   mu_beta_delta_z ~ normal(0, 1);
-  sd_beta_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_beta_delta_z[d] | sd_beta_delta_prior_family, sd_beta_delta_prior_p1, sd_beta_delta_prior_p2, sd_beta_delta_prior_p3);
   for (d in 1:(C - 1)) {
     raw_alpha_self_delta_z[d] ~ normal(0, 1);          // non-centred deviates for per-subject alpha_self deltas
     raw_alpha_other_outcome_delta_z[d] ~ normal(0, 1);

--- a/src/comp_model/inference/bayes/stan/programs/social_rl_self_reward_demo_mixture__study_subject_hierarchy.stan
+++ b/src/comp_model/inference/bayes/stan/programs/social_rl_self_reward_demo_mixture__study_subject_hierarchy.stan
@@ -33,22 +33,42 @@ data {
   real alpha_self_prior_p1;               // first hyperparameter of the alpha_self prior
   real alpha_self_prior_p2;               // second hyperparameter of the alpha_self prior
   real alpha_self_prior_p3;               // third hyperparameter of the alpha_self prior
+  int sd_alpha_self_prior_family;            // prior family code for the group-level alpha_self SD
+  real sd_alpha_self_prior_p1;               // first hyperparameter of the alpha_self SD prior
+  real sd_alpha_self_prior_p2;               // second hyperparameter of the alpha_self SD prior
+  real sd_alpha_self_prior_p3;               // third hyperparameter of the alpha_self SD prior
   int alpha_other_outcome_prior_family;   // prior family code for the group-level alpha_other_outcome mean
   real alpha_other_outcome_prior_p1;      // first hyperparameter of the alpha_other_outcome prior
   real alpha_other_outcome_prior_p2;      // second hyperparameter of the alpha_other_outcome prior
   real alpha_other_outcome_prior_p3;      // third hyperparameter of the alpha_other_outcome prior
+  int sd_alpha_other_outcome_prior_family;   // prior family code for the group-level alpha_other_outcome SD
+  real sd_alpha_other_outcome_prior_p1;      // first hyperparameter of the alpha_other_outcome SD prior
+  real sd_alpha_other_outcome_prior_p2;      // second hyperparameter of the alpha_other_outcome SD prior
+  real sd_alpha_other_outcome_prior_p3;      // third hyperparameter of the alpha_other_outcome SD prior
   int alpha_other_action_prior_family;    // prior family code for the group-level alpha_other_action mean
   real alpha_other_action_prior_p1;       // first hyperparameter of the alpha_other_action prior
   real alpha_other_action_prior_p2;       // second hyperparameter of the alpha_other_action prior
   real alpha_other_action_prior_p3;       // third hyperparameter of the alpha_other_action prior
+  int sd_alpha_other_action_prior_family;    // prior family code for the group-level alpha_other_action SD
+  real sd_alpha_other_action_prior_p1;       // first hyperparameter of the alpha_other_action SD prior
+  real sd_alpha_other_action_prior_p2;       // second hyperparameter of the alpha_other_action SD prior
+  real sd_alpha_other_action_prior_p3;       // third hyperparameter of the alpha_other_action SD prior
   int w_imitation_prior_family;           // prior family code for the group-level w_imitation mean
   real w_imitation_prior_p1;              // first hyperparameter of the w_imitation prior
   real w_imitation_prior_p2;              // second hyperparameter of the w_imitation prior
   real w_imitation_prior_p3;              // third hyperparameter of the w_imitation prior
+  int sd_w_imitation_prior_family;           // prior family code for the group-level w_imitation SD
+  real sd_w_imitation_prior_p1;              // first hyperparameter of the w_imitation SD prior
+  real sd_w_imitation_prior_p2;              // second hyperparameter of the w_imitation SD prior
+  real sd_w_imitation_prior_p3;              // third hyperparameter of the w_imitation SD prior
   int beta_prior_family;                  // prior family code for the group-level beta mean
   real beta_prior_p1;                     // first hyperparameter of the beta prior
   real beta_prior_p2;                     // second hyperparameter of the beta prior
   real beta_prior_p3;                     // third hyperparameter of the beta prior
+  int sd_beta_prior_family;                  // prior family code for the group-level beta SD
+  real sd_beta_prior_p1;                     // first hyperparameter of the beta SD prior
+  real sd_beta_prior_p2;                     // second hyperparameter of the beta SD prior
+  real sd_beta_prior_p3;                     // third hyperparameter of the beta SD prior
 }
 parameters {
   real mu_alpha_self_z;                   // group-level mean of alpha_self in unconstrained space
@@ -89,23 +109,23 @@ model {
   array[N] vector[A] T; // per-subject action-tendency vectors
 
   target += prior_lpdf(mu_alpha_self_z | alpha_self_prior_family, alpha_self_prior_p1, alpha_self_prior_p2, alpha_self_prior_p3);
-  sd_alpha_self_z ~ normal(0, 1);   // half-normal prior on group SD
+  target += prior_lpdf(sd_alpha_self_z | sd_alpha_self_prior_family, sd_alpha_self_prior_p1, sd_alpha_self_prior_p2, sd_alpha_self_prior_p3);   // configurable prior on group SD (constrained positive)
   raw_alpha_self_z ~ normal(0, 1);  // non-centred parameterisation
 
   target += prior_lpdf(mu_alpha_other_outcome_z | alpha_other_outcome_prior_family, alpha_other_outcome_prior_p1, alpha_other_outcome_prior_p2, alpha_other_outcome_prior_p3);
-  sd_alpha_other_outcome_z ~ normal(0, 1);
+  target += prior_lpdf(sd_alpha_other_outcome_z | sd_alpha_other_outcome_prior_family, sd_alpha_other_outcome_prior_p1, sd_alpha_other_outcome_prior_p2, sd_alpha_other_outcome_prior_p3);
   raw_alpha_other_outcome_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_alpha_other_action_z | alpha_other_action_prior_family, alpha_other_action_prior_p1, alpha_other_action_prior_p2, alpha_other_action_prior_p3);
-  sd_alpha_other_action_z ~ normal(0, 1);
+  target += prior_lpdf(sd_alpha_other_action_z | sd_alpha_other_action_prior_family, sd_alpha_other_action_prior_p1, sd_alpha_other_action_prior_p2, sd_alpha_other_action_prior_p3);
   raw_alpha_other_action_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_w_imitation_z | w_imitation_prior_family, w_imitation_prior_p1, w_imitation_prior_p2, w_imitation_prior_p3);
-  sd_w_imitation_z ~ normal(0, 1);
+  target += prior_lpdf(sd_w_imitation_z | sd_w_imitation_prior_family, sd_w_imitation_prior_p1, sd_w_imitation_prior_p2, sd_w_imitation_prior_p3);
   raw_w_imitation_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_beta_z | beta_prior_family, beta_prior_p1, beta_prior_p2, beta_prior_p3);
-  sd_beta_z ~ normal(0, 1);
+  target += prior_lpdf(sd_beta_z | sd_beta_prior_family, sd_beta_prior_p1, sd_beta_prior_p2, sd_beta_prior_p3);
   raw_beta_z ~ normal(0, 1);
 
   for (n in 1:N) Q[n] = rep_vector(q_init, A);      // initialise outcome-values for all subjects

--- a/src/comp_model/inference/bayes/stan/programs/social_rl_self_reward_demo_reward__study_subject_block_condition_hierarchy.stan
+++ b/src/comp_model/inference/bayes/stan/programs/social_rl_self_reward_demo_reward__study_subject_block_condition_hierarchy.stan
@@ -44,6 +44,30 @@ data {
   real beta_prior_p1;            // first hyperparameter of the beta prior
   real beta_prior_p2;            // second hyperparameter of the beta prior
   real beta_prior_p3;            // third hyperparameter of the beta prior
+  int sd_alpha_self_prior_family;   // prior family code for the group-level shared alpha_self SD
+  real sd_alpha_self_prior_p1;      // first hyperparameter of the shared alpha_self SD prior
+  real sd_alpha_self_prior_p2;      // second hyperparameter of the shared alpha_self SD prior
+  real sd_alpha_self_prior_p3;      // third hyperparameter of the shared alpha_self SD prior
+  int sd_alpha_other_prior_family;  // prior family code for the group-level shared alpha_other SD
+  real sd_alpha_other_prior_p1;     // first hyperparameter of the shared alpha_other SD prior
+  real sd_alpha_other_prior_p2;     // second hyperparameter of the shared alpha_other SD prior
+  real sd_alpha_other_prior_p3;     // third hyperparameter of the shared alpha_other SD prior
+  int sd_beta_prior_family;         // prior family code for the group-level shared beta SD
+  real sd_beta_prior_p1;            // first hyperparameter of the shared beta SD prior
+  real sd_beta_prior_p2;            // second hyperparameter of the shared beta SD prior
+  real sd_beta_prior_p3;            // third hyperparameter of the shared beta SD prior
+  int sd_alpha_self_delta_prior_family;   // prior family code for the group-level alpha_self delta SD
+  real sd_alpha_self_delta_prior_p1;      // first hyperparameter of the alpha_self delta SD prior
+  real sd_alpha_self_delta_prior_p2;      // second hyperparameter of the alpha_self delta SD prior
+  real sd_alpha_self_delta_prior_p3;      // third hyperparameter of the alpha_self delta SD prior
+  int sd_alpha_other_delta_prior_family;  // prior family code for the group-level alpha_other delta SD
+  real sd_alpha_other_delta_prior_p1;     // first hyperparameter of the alpha_other delta SD prior
+  real sd_alpha_other_delta_prior_p2;     // second hyperparameter of the alpha_other delta SD prior
+  real sd_alpha_other_delta_prior_p3;     // third hyperparameter of the alpha_other delta SD prior
+  int sd_beta_delta_prior_family;         // prior family code for the group-level beta delta SD
+  real sd_beta_delta_prior_p1;            // first hyperparameter of the beta delta SD prior
+  real sd_beta_delta_prior_p2;            // second hyperparameter of the beta delta SD prior
+  real sd_beta_delta_prior_p3;            // third hyperparameter of the beta delta SD prior
 }
 parameters {
   // Population-level: shared
@@ -114,24 +138,27 @@ model {
 
   // Priors: shared
   target += prior_lpdf(mu_alpha_self_shared_z | alpha_self_prior_family, alpha_self_prior_p1, alpha_self_prior_p2, alpha_self_prior_p3);
-  sd_alpha_self_shared_z ~ normal(0, 1);   // half-normal prior on group SD
+  target += prior_lpdf(sd_alpha_self_shared_z | sd_alpha_self_prior_family, sd_alpha_self_prior_p1, sd_alpha_self_prior_p2, sd_alpha_self_prior_p3);
   raw_alpha_self_shared_z ~ normal(0, 1);  // non-centred parameterisation
 
   target += prior_lpdf(mu_alpha_other_shared_z | alpha_other_prior_family, alpha_other_prior_p1, alpha_other_prior_p2, alpha_other_prior_p3);
-  sd_alpha_other_shared_z ~ normal(0, 1);
+  target += prior_lpdf(sd_alpha_other_shared_z | sd_alpha_other_prior_family, sd_alpha_other_prior_p1, sd_alpha_other_prior_p2, sd_alpha_other_prior_p3);
   raw_alpha_other_shared_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_beta_shared_z | beta_prior_family, beta_prior_p1, beta_prior_p2, beta_prior_p3);
-  sd_beta_shared_z ~ normal(0, 1);
+  target += prior_lpdf(sd_beta_shared_z | sd_beta_prior_family, sd_beta_prior_p1, sd_beta_prior_p2, sd_beta_prior_p3);
   raw_beta_shared_z ~ normal(0, 1);
 
   // Priors: deltas
   mu_alpha_self_delta_z ~ normal(0, 1);   // regularising prior on group-level delta means
-  sd_alpha_self_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_alpha_self_delta_z[d] | sd_alpha_self_delta_prior_family, sd_alpha_self_delta_prior_p1, sd_alpha_self_delta_prior_p2, sd_alpha_self_delta_prior_p3);
   mu_alpha_other_delta_z ~ normal(0, 1);
-  sd_alpha_other_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_alpha_other_delta_z[d] | sd_alpha_other_delta_prior_family, sd_alpha_other_delta_prior_p1, sd_alpha_other_delta_prior_p2, sd_alpha_other_delta_prior_p3);
   mu_beta_delta_z ~ normal(0, 1);
-  sd_beta_delta_z ~ normal(0, 1);
+  for (d in 1:(C - 1))
+    target += prior_lpdf(sd_beta_delta_z[d] | sd_beta_delta_prior_family, sd_beta_delta_prior_p1, sd_beta_delta_prior_p2, sd_beta_delta_prior_p3);
   for (d in 1:(C - 1)) {
     raw_alpha_self_delta_z[d] ~ normal(0, 1);  // non-centred deviates for per-subject alpha_self deltas
     raw_alpha_other_delta_z[d] ~ normal(0, 1);

--- a/src/comp_model/inference/bayes/stan/programs/social_rl_self_reward_demo_reward__study_subject_hierarchy.stan
+++ b/src/comp_model/inference/bayes/stan/programs/social_rl_self_reward_demo_reward__study_subject_hierarchy.stan
@@ -32,14 +32,26 @@ data {
   real alpha_self_prior_p1;      // first hyperparameter of the alpha_self prior
   real alpha_self_prior_p2;      // second hyperparameter of the alpha_self prior
   real alpha_self_prior_p3;      // third hyperparameter of the alpha_self prior
+  int sd_alpha_self_prior_family;   // prior family code for the group-level alpha_self SD
+  real sd_alpha_self_prior_p1;      // first hyperparameter of the alpha_self SD prior
+  real sd_alpha_self_prior_p2;      // second hyperparameter of the alpha_self SD prior
+  real sd_alpha_self_prior_p3;      // third hyperparameter of the alpha_self SD prior
   int alpha_other_prior_family;  // prior family code for the group-level alpha_other mean
   real alpha_other_prior_p1;     // first hyperparameter of the alpha_other prior
   real alpha_other_prior_p2;     // second hyperparameter of the alpha_other prior
   real alpha_other_prior_p3;     // third hyperparameter of the alpha_other prior
+  int sd_alpha_other_prior_family;  // prior family code for the group-level alpha_other SD
+  real sd_alpha_other_prior_p1;     // first hyperparameter of the alpha_other SD prior
+  real sd_alpha_other_prior_p2;     // second hyperparameter of the alpha_other SD prior
+  real sd_alpha_other_prior_p3;     // third hyperparameter of the alpha_other SD prior
   int beta_prior_family;         // prior family code for the group-level beta mean
   real beta_prior_p1;            // first hyperparameter of the beta prior
   real beta_prior_p2;            // second hyperparameter of the beta prior
   real beta_prior_p3;            // third hyperparameter of the beta prior
+  int sd_beta_prior_family;         // prior family code for the group-level beta SD
+  real sd_beta_prior_p1;            // first hyperparameter of the beta SD prior
+  real sd_beta_prior_p2;            // second hyperparameter of the beta SD prior
+  real sd_beta_prior_p3;            // third hyperparameter of the beta SD prior
 }
 parameters {
   real mu_alpha_self_z;              // group-level mean of alpha_self in unconstrained space
@@ -66,15 +78,15 @@ model {
   array[N] vector[A] Q; // per-subject action-value vectors
 
   target += prior_lpdf(mu_alpha_self_z | alpha_self_prior_family, alpha_self_prior_p1, alpha_self_prior_p2, alpha_self_prior_p3);
-  sd_alpha_self_z ~ normal(0, 1);   // half-normal prior on group SD
+  target += prior_lpdf(sd_alpha_self_z | sd_alpha_self_prior_family, sd_alpha_self_prior_p1, sd_alpha_self_prior_p2, sd_alpha_self_prior_p3);   // configurable prior on group SD (constrained positive)
   raw_alpha_self_z ~ normal(0, 1);  // non-centred parameterisation
 
   target += prior_lpdf(mu_alpha_other_z | alpha_other_prior_family, alpha_other_prior_p1, alpha_other_prior_p2, alpha_other_prior_p3);
-  sd_alpha_other_z ~ normal(0, 1);
+  target += prior_lpdf(sd_alpha_other_z | sd_alpha_other_prior_family, sd_alpha_other_prior_p1, sd_alpha_other_prior_p2, sd_alpha_other_prior_p3);
   raw_alpha_other_z ~ normal(0, 1);
 
   target += prior_lpdf(mu_beta_z | beta_prior_family, beta_prior_p1, beta_prior_p2, beta_prior_p3);
-  sd_beta_z ~ normal(0, 1);
+  target += prior_lpdf(sd_beta_z | sd_beta_prior_family, sd_beta_prior_p1, sd_beta_prior_p2, sd_beta_prior_p3);
   raw_beta_z ~ normal(0, 1);
 
   for (n in 1:N) Q[n] = rep_vector(q_init, A); // initialise Q-values for all subjects

--- a/src/comp_model/inference/config.py
+++ b/src/comp_model/inference/config.py
@@ -69,6 +69,12 @@ class InferenceConfig:
         Only used by the Bayesian backend. Parameters without an entry
         fall back to ``Normal(0, 2)`` on the unconstrained scale.
 
+        SD priors for hierarchical models can be configured with the
+        ``sd_`` prefix (e.g., ``"sd_alpha"``).  When omitted, SD priors
+        default to ``Normal(0, 1)``.  For condition-hierarchy delta SD
+        priors, use the ``_delta`` suffix (e.g., ``"sd_alpha_delta"``);
+        these fall back to the base SD prior, then to ``Normal(0, 1)``.
+
     Notes
     -----
     ``InferenceConfig`` selects the backend entry point only. Kernel semantics,

--- a/tests/test_inference/test_hierarchical_sd_priors.py
+++ b/tests/test_inference/test_hierarchical_sd_priors.py
@@ -1,0 +1,298 @@
+"""Tests for configurable hierarchical SD prior export through Stan adapters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from comp_model.data.schema import Block, Dataset, Event, EventPhase, SubjectData, Trial
+from comp_model.environments.bandit import StationaryBanditEnvironment
+from comp_model.inference.bayes.stan.adapters.asocial_q_learning import (
+    AsocialQLearningStanAdapter,
+)
+from comp_model.inference.bayes.stan.adapters.asocial_rl_asymmetric import (
+    AsocialRlAsymmetricStanAdapter,
+)
+from comp_model.inference.bayes.stan.adapters.social_rl_demo_mixture import (
+    SocialRlDemoMixtureStanAdapter,
+)
+from comp_model.inference.bayes.stan.adapters.social_rl_self_reward_demo_action_mixture import (
+    SocialRlSelfRewardDemoActionMixtureStanAdapter,
+)
+from comp_model.inference.bayes.stan.adapters.social_rl_self_reward_demo_mixture import (
+    SocialRlSelfRewardDemoMixtureStanAdapter,
+)
+from comp_model.inference.bayes.stan.adapters.social_rl_self_reward_demo_reward import (
+    SocialRlSelfRewardDemoRewardStanAdapter,
+)
+from comp_model.inference.config import HierarchyStructure
+from comp_model.models.condition.shared_delta import SharedDeltaLayout
+from comp_model.models.kernels.asocial_q_learning import AsocialQLearningKernel
+from comp_model.runtime.engine import SimulationConfig, simulate_dataset
+from comp_model.tasks.schemas import ASOCIAL_BANDIT_SCHEMA, SOCIAL_PRE_CHOICE_SCHEMA
+from comp_model.tasks.spec import BlockSpec, TaskSpec
+
+
+def _asocial_dataset(include_conditions: bool) -> Dataset:
+    """Create a small asocial dataset for hierarchical adapter tests."""
+
+    blocks = [
+        BlockSpec(
+            condition="baseline",
+            n_trials=2,
+            schema=ASOCIAL_BANDIT_SCHEMA,
+            metadata={"n_actions": 2},
+        )
+    ]
+    if include_conditions:
+        blocks.append(
+            BlockSpec(
+                condition="social",
+                n_trials=2,
+                schema=ASOCIAL_BANDIT_SCHEMA,
+                metadata={"n_actions": 2},
+            )
+        )
+
+    task = TaskSpec(task_id="hierarchical-sd-priors", blocks=tuple(blocks))
+    kernel = AsocialQLearningKernel()
+    params = kernel.parse_params({"alpha": 0.0, "beta": 1.0})
+    return simulate_dataset(
+        task=task,
+        env_factory=lambda: StationaryBanditEnvironment(n_actions=2, reward_probs=(0.8, 0.2)),
+        kernel=kernel,
+        params_per_subject={"s1": params, "s2": params},
+        config=SimulationConfig(seed=23),
+    )
+
+
+def _social_trial(
+    trial_index: int,
+    *,
+    action: int,
+    reward: float,
+    social_action: int,
+    social_reward: float,
+) -> Trial:
+    """Create one minimal social trial matching ``SOCIAL_PRE_CHOICE_SCHEMA``."""
+
+    return Trial(
+        trial_index=trial_index,
+        events=(
+            Event(
+                phase=EventPhase.INPUT,
+                event_index=0,
+                node_id="main",
+                actor_id="demonstrator",
+                payload={"available_actions": (0, 1)},
+            ),
+            Event(
+                phase=EventPhase.DECISION,
+                event_index=1,
+                node_id="main",
+                actor_id="demonstrator",
+                payload={"action": social_action},
+            ),
+            Event(
+                phase=EventPhase.OUTCOME,
+                event_index=2,
+                node_id="main",
+                actor_id="demonstrator",
+                payload={"reward": social_reward},
+            ),
+            Event(
+                phase=EventPhase.UPDATE,
+                event_index=3,
+                node_id="main",
+                actor_id="demonstrator",
+                payload={"choice": social_action, "reward": social_reward},
+            ),
+            Event(
+                phase=EventPhase.UPDATE,
+                event_index=4,
+                node_id="main",
+                actor_id="demonstrator",
+                payload={"choice": social_action, "reward": social_reward},
+            ),
+            Event(
+                phase=EventPhase.INPUT,
+                event_index=5,
+                node_id="main",
+                payload={"available_actions": (0, 1)},
+            ),
+            Event(
+                phase=EventPhase.DECISION,
+                event_index=6,
+                node_id="main",
+                payload={"action": action},
+            ),
+            Event(
+                phase=EventPhase.OUTCOME,
+                event_index=7,
+                node_id="main",
+                payload={"reward": reward},
+            ),
+            Event(
+                phase=EventPhase.UPDATE,
+                event_index=8,
+                node_id="main",
+                payload={"choice": action, "reward": reward},
+            ),
+        ),
+    )
+
+
+def _social_subject(subject_id: str, include_conditions: bool) -> SubjectData:
+    """Create a small social subject for hierarchical adapter tests."""
+
+    blocks = [
+        Block(
+            block_index=0,
+            condition="baseline",
+            schema_id="social_pre_choice",
+            trials=(
+                _social_trial(
+                    0,
+                    action=0,
+                    reward=1.0,
+                    social_action=1,
+                    social_reward=0.0,
+                ),
+            ),
+        )
+    ]
+    if include_conditions:
+        blocks.append(
+            Block(
+                block_index=1,
+                condition="social",
+                schema_id="social_pre_choice",
+                trials=(
+                    _social_trial(
+                        0,
+                        action=1,
+                        reward=0.0,
+                        social_action=0,
+                        social_reward=1.0,
+                    ),
+                ),
+            )
+        )
+
+    return SubjectData(subject_id=subject_id, blocks=tuple(blocks))
+
+
+def _social_dataset(include_conditions: bool) -> Dataset:
+    """Create a small social dataset for hierarchical adapter tests."""
+
+    return Dataset(
+        subjects=(
+            _social_subject("social-s1", include_conditions),
+            _social_subject("social-s2", include_conditions),
+        )
+    )
+
+
+_ASOCIAL_ADAPTER_CASES = [
+    ("asocial_q_learning", AsocialQLearningStanAdapter(), _asocial_dataset, ASOCIAL_BANDIT_SCHEMA),
+    (
+        "asocial_rl_asymmetric",
+        AsocialRlAsymmetricStanAdapter(),
+        _asocial_dataset,
+        ASOCIAL_BANDIT_SCHEMA,
+    ),
+]
+
+_SOCIAL_ADAPTER_CASES = [
+    (
+        "social_rl_self_reward_demo_reward",
+        SocialRlSelfRewardDemoRewardStanAdapter(),
+        _social_dataset,
+        SOCIAL_PRE_CHOICE_SCHEMA,
+    ),
+    (
+        "social_rl_demo_mixture",
+        SocialRlDemoMixtureStanAdapter(),
+        _social_dataset,
+        SOCIAL_PRE_CHOICE_SCHEMA,
+    ),
+    (
+        "social_rl_self_reward_demo_action_mixture",
+        SocialRlSelfRewardDemoActionMixtureStanAdapter(),
+        _social_dataset,
+        SOCIAL_PRE_CHOICE_SCHEMA,
+    ),
+    (
+        "social_rl_self_reward_demo_mixture",
+        SocialRlSelfRewardDemoMixtureStanAdapter(),
+        _social_dataset,
+        SOCIAL_PRE_CHOICE_SCHEMA,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("adapter", "dataset_factory", "schema"),
+    [(case[1], case[2], case[3]) for case in _ASOCIAL_ADAPTER_CASES + _SOCIAL_ADAPTER_CASES],
+    ids=[case[0] for case in _ASOCIAL_ADAPTER_CASES + _SOCIAL_ADAPTER_CASES],
+)
+def test_study_subject_adapters_export_sd_prior_keys(
+    adapter: Any,
+    dataset_factory: Any,
+    schema: Any,
+) -> None:
+    """Ensure study-level hierarchical adapters export SD prior metadata."""
+
+    dataset = dataset_factory(False)
+
+    stan_data = adapter.build_stan_data(dataset, schema, HierarchyStructure.STUDY_SUBJECT)
+
+    expected = {
+        f"sd_{parameter.name}_prior_family" for parameter in adapter.kernel_spec().parameter_specs
+    }
+    unexpected_delta = {
+        f"sd_{parameter.name}_delta_prior_family"
+        for parameter in adapter.kernel_spec().parameter_specs
+    }
+
+    assert expected.issubset(stan_data)
+    assert unexpected_delta.isdisjoint(stan_data)
+
+
+@pytest.mark.parametrize(
+    ("adapter", "dataset_factory", "schema"),
+    [(case[1], case[2], case[3]) for case in _ASOCIAL_ADAPTER_CASES + _SOCIAL_ADAPTER_CASES],
+    ids=[case[0] for case in _ASOCIAL_ADAPTER_CASES + _SOCIAL_ADAPTER_CASES],
+)
+def test_study_subject_condition_adapters_export_shared_and_delta_sd_prior_keys(
+    adapter: Any,
+    dataset_factory: Any,
+    schema: Any,
+) -> None:
+    """Ensure study+condition hierarchical adapters export shared and delta SD priors."""
+
+    dataset = dataset_factory(True)
+    layout = SharedDeltaLayout(
+        kernel_spec=adapter.kernel_spec(),
+        conditions=("baseline", "social"),
+        baseline_condition="baseline",
+    )
+
+    stan_data = adapter.build_stan_data(
+        dataset,
+        schema,
+        HierarchyStructure.STUDY_SUBJECT_BLOCK_CONDITION,
+        layout=layout,
+    )
+
+    expected_shared = {
+        f"sd_{parameter.name}_prior_family" for parameter in adapter.kernel_spec().parameter_specs
+    }
+    expected_delta = {
+        f"sd_{parameter.name}_delta_prior_family"
+        for parameter in adapter.kernel_spec().parameter_specs
+    }
+
+    assert expected_shared.issubset(stan_data)
+    assert expected_delta.issubset(stan_data)

--- a/tests/test_inference/test_stan_data_builder.py
+++ b/tests/test_inference/test_stan_data_builder.py
@@ -7,12 +7,14 @@ from comp_model.environments.bandit import StationaryBanditEnvironment
 from comp_model.inference.bayes.stan.data_builder import (
     add_condition_data,
     add_prior_data,
+    add_sd_prior_data,
     add_state_reset_data,
     dataset_to_stan_data,
     dataset_to_step_data,
     subject_to_stan_data,
     subject_to_step_data,
 )
+from comp_model.inference.config import PriorSpec
 from comp_model.models.condition.shared_delta import SharedDeltaLayout
 from comp_model.models.kernels.asocial_q_learning import AsocialQLearningKernel
 from comp_model.runtime.engine import SimulationConfig, simulate_dataset, simulate_subject
@@ -149,6 +151,62 @@ def test_condition_prior_and_reset_data_are_added() -> None:
     assert "alpha_prior_family" in stan_data
     assert "beta_prior_p2" in stan_data
     assert stan_data["reset_on_block"] == 1
+
+
+def test_add_sd_prior_data_exports_default_normal_priors() -> None:
+    """Ensure SD prior export defaults to Normal(0, 1) for hierarchical fits.
+
+    Returns
+    -------
+    None
+        This test asserts default SD prior metadata.
+    """
+
+    kernel = AsocialQLearningKernel()
+    stan_data: dict[str, int | float] = {}
+
+    add_sd_prior_data(stan_data, kernel.spec())
+
+    assert stan_data["sd_alpha_prior_family"] == 1
+    assert stan_data["sd_alpha_prior_p1"] == 0.0
+    assert stan_data["sd_alpha_prior_p2"] == 1.0
+    assert stan_data["sd_alpha_prior_p3"] == 0.0
+    assert stan_data["sd_beta_prior_family"] == 1
+    assert "sd_alpha_delta_prior_family" not in stan_data
+
+
+def test_add_sd_prior_data_exports_explicit_and_delta_fallback_priors() -> None:
+    """Ensure explicit SD priors and delta fallbacks are exported correctly.
+
+    Returns
+    -------
+    None
+        This test asserts custom SD prior metadata and delta fallback behavior.
+    """
+
+    kernel = AsocialQLearningKernel()
+    stan_data: dict[str, int | float] = {}
+    prior_specs = {
+        "sd_alpha": PriorSpec(family="cauchy", kwargs={"mu": 0.0, "sigma": 0.3}),
+        "sd_beta_delta": PriorSpec(
+            family="student_t",
+            kwargs={"mu": 0.0, "sigma": 0.2, "df": 4.0},
+        ),
+    }
+
+    add_sd_prior_data(stan_data, kernel.spec(), prior_specs, include_delta=True)
+
+    assert stan_data["sd_alpha_prior_family"] == 2
+    assert stan_data["sd_alpha_prior_p1"] == 0.0
+    assert stan_data["sd_alpha_prior_p2"] == 0.3
+    assert stan_data["sd_alpha_prior_p3"] == 0.0
+    assert stan_data["sd_alpha_delta_prior_family"] == 2
+    assert stan_data["sd_alpha_delta_prior_p2"] == 0.3
+    assert stan_data["sd_beta_prior_family"] == 1
+    assert stan_data["sd_beta_delta_prior_family"] == 3
+    assert stan_data["sd_beta_delta_prior_p1"] == 0.0
+    assert stan_data["sd_beta_delta_prior_p2"] == 0.2
+    assert stan_data["sd_beta_delta_prior_p3"] == 4.0
 
 
 def test_add_state_reset_data_exports_per_block_policy() -> None:


### PR DESCRIPTION
## Summary
- add configurable hierarchical SD prior export through `add_sd_prior_data()` and re-export it from the Stan package surface
- wire all hierarchical Stan adapters to pass `sd_<name>` priors for study fits and `sd_<name>_delta` priors for study+condition fits
- update the hierarchical Stan programs and add focused builder/adapter tests for the new SD-prior contract

## Why
Hierarchical Stan programs on this branch were updated to consume configurable SD-prior inputs, but the Python adapter layer still only emitted the parameter-mean prior data. That left study-level fits with missing `sd_*_prior_*` inputs even though the Stan programs expected them.

## Impact
Users can now configure group-level standard deviation priors via `InferenceConfig.prior_specs` using keys like `sd_alpha` and `sd_alpha_delta`. When those keys are omitted, hierarchical fits fall back to the documented `Normal(0, 1)` SD prior.

## Root Cause
The feature was implemented halfway: the config docs, Stan data-builder helper, and hierarchical Stan programs were changed, but the adapter layer was not updated to include the new SD-prior payload in hierarchical Stan data.

## Validation
- `uv run pytest tests/test_inference/test_stan_data_builder.py tests/test_inference/test_hierarchical_sd_priors.py tests/test_inference/test_stan_adapter.py tests/test_inference/test_social_stan_adapter.py -q`
- `uv run ruff check src/comp_model/inference/bayes/stan/adapters/asocial_q_learning.py src/comp_model/inference/bayes/stan/adapters/asocial_rl_asymmetric.py src/comp_model/inference/bayes/stan/adapters/social_rl_demo_mixture.py src/comp_model/inference/bayes/stan/adapters/social_rl_self_reward_demo_action_mixture.py src/comp_model/inference/bayes/stan/adapters/social_rl_self_reward_demo_mixture.py src/comp_model/inference/bayes/stan/adapters/social_rl_self_reward_demo_reward.py src/comp_model/inference/bayes/stan/__init__.py tests/test_inference/test_stan_data_builder.py tests/test_inference/test_hierarchical_sd_priors.py`