### PR TITLE
[codex] fix demo-action sticky simulation choice memory

### DIFF
--- a/src/comp_model/models/kernels/social_rl_demo_action_bias_sticky.py
+++ b/src/comp_model/models/kernels/social_rl_demo_action_bias_sticky.py
@@ -112,6 +112,23 @@ class SocialRlDemoActionBiasStickyKernel(
             logits.append(logit)
         return stable_softmax(logits)
 
+    def observe_decision(
+        self,
+        state: SocialRlDemoActionBiasStickyState,
+        view: DecisionTrialView,
+        params: SocialRlDemoActionBiasStickyParams,
+    ) -> SocialRlDemoActionBiasStickyState:
+        """Store the participant's most recent own choice at decision time."""
+
+        del params
+        if view.actor_id != view.learner_id or view.action is None:
+            return state
+
+        return SocialRlDemoActionBiasStickyState(
+            last_demo_action=state.last_demo_action,
+            last_self_action=view.action,
+        )
+
     def update(
         self,
         state: SocialRlDemoActionBiasStickyState,

--- a/tests/test_models/test_social_rl_demo_action_bias_sticky.py
+++ b/tests/test_models/test_social_rl_demo_action_bias_sticky.py
@@ -65,6 +65,28 @@ def test_self_update_preserves_demo_action_and_refreshes_own_choice() -> None:
     assert updated.last_self_action == 0
 
 
+def test_observe_decision_stores_previous_own_choice() -> None:
+    """Decision-time observation should refresh own-choice memory."""
+
+    kernel = SocialRlDemoActionBiasStickyKernel()
+    params = kernel.parse_params({"demo_bias": 0.0, "stickiness": 0.0})
+    state = kernel.initial_state(2, params)
+    state.last_demo_action = 1
+
+    decision_view = DecisionTrialView(
+        trial_index=0,
+        available_actions=(0, 1),
+        actor_id="subject",
+        learner_id="subject",
+        action=0,
+        reward=None,
+    )
+    observed = kernel.observe_decision(state, decision_view, params)
+
+    assert observed.last_demo_action == 1
+    assert observed.last_self_action == 0
+
+
 def test_action_probabilities_favor_latest_demo_action_with_positive_demo_bias() -> None:
     """A positive demo-bias term should favor the observed demonstrator action."""
 


### PR DESCRIPTION
## What changed
- added `observe_decision(...)` to `SocialRlDemoActionBiasStickyKernel` so own-choice memory is updated at decision time
- added a focused regression test covering decision-time self-choice memory for the sticky demo-action kernel

## Why it changed
`demo_action_sticky` uses self stickiness, so its latent `last_self_action` must update when the subject makes a choice, even on schemas without a subject self-update event.

## Root cause
The runtime simulator calls `observe_decision(...)` immediately after each decision. Most sticky kernels override that hook, but `SocialRlDemoActionBiasStickyKernel` did not. As a result, simulated data under no-self-outcome schemas dropped self-stickiness during generation, while the Stan fit still modeled stickiness.

## Impact
This makes simulation and recovery for `demo_action_sticky` consistent with the fitted model, especially for schemas such as `social_pre_choice_no_self_outcome` where there is no subject update row after the subject choice.

## Validation
- `uv run pytest /Users/morishitag/comp_model_v3/tests/test_models/test_social_rl_demo_action_bias_sticky.py -q`
